### PR TITLE
add Output for BastionSecurityGroup

### DIFF
--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -333,6 +333,11 @@ Outputs:
       - EnableBastion
       - !GetAtt BastionStack.Outputs.EIP1
       - ""
+  BastionSecurityGroup:
+    Value: !If
+      - EnableBastion
+      - !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+      - ""
   EKSClusterName:
     Value: !GetAtt EKSControlPlane.EKSName
   NodeInstanceProfile:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added BastionSecurityGroup as a stack output. This allows framework users to enable inbound SSH access to node groups from the bastion host, if needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
