### PR TITLE
Optionally deploy cluster auto-scaler

### DIFF
--- a/templates/amazon-eks-cluster-autoscaler.template.yaml
+++ b/templates/amazon-eks-cluster-autoscaler.template.yaml
@@ -1,0 +1,82 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Deploys the auto-scaler helm chart into an existing kubernetes cluster"
+Parameters:
+  HelmLambdaArn:
+    Type: String
+  KubeConfigPath:
+    Type: String
+  KubeConfigKmsContext:
+    Type: String
+    Default: "EKSQuickStart"
+  NodeInstanceRoleName:
+    Type: String
+  NodeAutoScalingGroup:
+    Type: String
+  EksClusterName:
+    Type: String
+  KubernetesVersion:
+    Type: String
+    AllowedValues: [ "1.11", "1.10" ]
+    Default: "1.11"
+# NOTE: The cluster autoscaler version number is dependant on the K8S version it is being 
+#       deployed into. See...
+#       https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases
+#       https://github.com/kubernetes/autoscaler/releases
+Mappings:
+  K8sVersionMap:
+    "1.11":
+      ImageTag: v1.3.8
+    "1.10":
+      ImageTag: v1.2.5
+Resources:
+  # Policy to apply to NodeInstanceRole
+  ClusterAutoScalerPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: cluster-autoscaler
+      PolicyDocument: 
+        Version: "2012-10-17"
+        Statement: 
+          - Effect: Allow
+            Action:
+              - autoscaling:DescribeAutoScalingGroups
+              - autoscaling:DescribeAutoScalingInstances
+              - autoscaling:DescribeLaunchConfigurations
+              - autoscaling:DescribeTags
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - autoscaling:SetDesiredCapacity
+              - autoscaling:TerminateInstanceInAutoScalingGroup
+            Resource: !Sub "arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${NodeAutoScalingGroup}"
+      Roles: 
+        - !Ref NodeInstanceRoleName
+
+  # Install auto-scaler helm chart
+  AutoScalerHelmChart:
+    DependsOn:
+      - ClusterAutoScalerPolicy
+    Type: "Custom::Helm"
+    Version: "1.0"
+    Properties:
+      ServiceToken: !Ref HelmLambdaArn
+      KubeConfigPath: !Ref KubeConfigPath
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      Namespace: kube-system
+      Chart: stable/cluster-autoscaler
+      Values:
+        awsRegion: !Ref AWS::Region
+        cloudProvider: aws
+        image.tag: !FindInMap
+          - K8sVersionMap
+          - !Ref KubernetesVersion
+          - ImageTag
+        rbac.create: true
+        rbac.pspEnabled: true
+        autoDiscovery.clusterName: !Ref EksClusterName
+        sslCertPath: /etc/ssl/certs/ca-bundle.crt
+        extraArgs.balance-similar-node-groups: false
+        extraArgs.expander: random
+Outputs:
+  AutoScalerReleaseName:
+    Value: !Ref AutoScalerHelmChart

--- a/templates/amazon-eks-master-existing-vpc.template.yaml
+++ b/templates/amazon-eks-master-existing-vpc.template.yaml
@@ -23,12 +23,10 @@ Metadata:
         Parameters:
           - NodeInstanceType
           - NumberOfNodes
-          - MaxNumberOfNodes
           - NodeGroupName
           - NodeVolumeSize
           - AdditionalEKSAdminArns
           - KubernetesVersion
-          - ProvisionClusterAutoScaler
       - Label:
           default: AWS Quick Start configuration
         Parameters:
@@ -48,8 +46,6 @@ Metadata:
         default: Nodes instance type
       NumberOfNodes:
         default: Number of nodes
-      MaxNumberOfNodes:
-        default: Maximum number of nodes
       NodeGroupName:
         default: Node group name
       NodeVolumeSize:
@@ -72,8 +68,6 @@ Metadata:
         default: Additional EKS admin ARNs
       KubernetesVersion:
         default: Kubernetes version
-      ProvisionClusterAutoScaler:
-        default: Provision Kubernetes cluster auto-scaler
       LambdaZipsBucketName:
         default: Lambda zips bucket name
 Parameters:
@@ -199,10 +193,6 @@ Parameters:
     Default: 3
     Description: The number of Amazon EKS node instances. The default is one for each of the three Availability Zones.
     Type: Number
-  MaxNumberOfNodes:
-    Default: 3
-    Description: The maximum number of Amazon EKS node instances.
-    Type: Number
   NodeGroupName:
     Default: Default
     Description: The name for EKS node group.
@@ -216,11 +206,6 @@ Parameters:
     AllowedValues: [ "1.11", "1.10" ]
     Description: The Kubernetes control plane version.
     Default: "1.11"
-  ProvisionClusterAutoScaler:
-    Description: Specifies whether the Kubernetes cluster auto-scaler is provisioned
-    Type: String
-    AllowedValues: [ "Enabled", "Disabled" ]
-    Default: "Disabled"
   LambdaZipsBucketName:
     Description: '[OPTIONAL] The name of the S3 bucket where the Lambda .zip files should be placed. If you leave this parameter blank, an S3 bucket will be created.'
     Type: String
@@ -281,7 +266,7 @@ Resources:
         PrivateSubnet2ID: !Ref PrivateSubnet2ID
         PrivateSubnet3ID: !Ref PrivateSubnet3ID
         NumberOfNodes: !Ref NumberOfNodes
-        MaxNumberOfNodes: !Ref MaxNumberOfNodes
+        MaxNumberOfNodes: !Ref NumberOfNodes
         NodeGroupName: !Ref NodeGroupName
         NodeVolumeSize: !Ref NodeVolumeSize
         LambdaZipsBucketName: !Ref LambdaZipsBucketName
@@ -290,7 +275,7 @@ Resources:
         AdditionalEKSAdminArns: !Join [ ",", !Ref AdditionalEKSAdminArns ]
         VPCID: !Ref VPCID
         KubernetesVersion: !Ref KubernetesVersion
-        ProvisionClusterAutoScaler: !Ref ProvisionClusterAutoScaler
+        ProvisionClusterAutoScaler: Disabled
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/amazon-eks-master-existing-vpc.template.yaml
+++ b/templates/amazon-eks-master-existing-vpc.template.yaml
@@ -23,10 +23,12 @@ Metadata:
         Parameters:
           - NodeInstanceType
           - NumberOfNodes
+          - MaxNumberOfNodes
           - NodeGroupName
           - NodeVolumeSize
           - AdditionalEKSAdminArns
           - KubernetesVersion
+          - ProvisionClusterAutoScaler
       - Label:
           default: AWS Quick Start configuration
         Parameters:
@@ -46,6 +48,8 @@ Metadata:
         default: Nodes instance type
       NumberOfNodes:
         default: Number of nodes
+      MaxNumberOfNodes:
+        default: Maximum number of nodes
       NodeGroupName:
         default: Node group name
       NodeVolumeSize:
@@ -68,6 +72,8 @@ Metadata:
         default: Additional EKS admin ARNs
       KubernetesVersion:
         default: Kubernetes version
+      ProvisionClusterAutoScaler:
+        default: Provision Kubernetes cluster auto-scaler
       LambdaZipsBucketName:
         default: Lambda zips bucket name
 Parameters:
@@ -193,6 +199,10 @@ Parameters:
     Default: 3
     Description: The number of Amazon EKS node instances. The default is one for each of the three Availability Zones.
     Type: Number
+  MaxNumberOfNodes:
+    Default: 3
+    Description: The maximum number of Amazon EKS node instances.
+    Type: Number
   NodeGroupName:
     Default: Default
     Description: The name for EKS node group.
@@ -206,6 +216,11 @@ Parameters:
     AllowedValues: [ "1.11", "1.10" ]
     Description: The Kubernetes control plane version.
     Default: "1.11"
+  ProvisionClusterAutoScaler:
+    Description: Specifies whether the Kubernetes cluster auto-scaler is provisioned
+    Type: String
+    AllowedValues: [ "Enabled", "Disabled" ]
+    Default: "Disabled"
   LambdaZipsBucketName:
     Description: '[OPTIONAL] The name of the S3 bucket where the Lambda .zip files should be placed. If you leave this parameter blank, an S3 bucket will be created.'
     Type: String
@@ -266,6 +281,7 @@ Resources:
         PrivateSubnet2ID: !Ref PrivateSubnet2ID
         PrivateSubnet3ID: !Ref PrivateSubnet3ID
         NumberOfNodes: !Ref NumberOfNodes
+        MaxNumberOfNodes: !Ref MaxNumberOfNodes
         NodeGroupName: !Ref NodeGroupName
         NodeVolumeSize: !Ref NodeVolumeSize
         LambdaZipsBucketName: !Ref LambdaZipsBucketName
@@ -274,6 +290,7 @@ Resources:
         AdditionalEKSAdminArns: !Join [ ",", !Ref AdditionalEKSAdminArns ]
         VPCID: !Ref VPCID
         KubernetesVersion: !Ref KubernetesVersion
+        ProvisionClusterAutoScaler: !Ref ProvisionClusterAutoScaler
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/amazon-eks-master.template.yaml
+++ b/templates/amazon-eks-master.template.yaml
@@ -24,12 +24,10 @@ Metadata:
         Parameters:
           - NodeInstanceType
           - NumberOfNodes
-          - MaxNumberOfNodes
           - NodeGroupName
           - NodeVolumeSize
           - AdditionalEKSAdminArns
           - KubernetesVersion
-          - ProvisionClusterAutoScaler
       - Label:
           default: AWS Quick Start configuration
         Parameters:
@@ -65,8 +63,6 @@ Metadata:
         default: Nodes instance type
       NumberOfNodes:
         default: Number of nodes
-      MaxNumberOfNodes:
-        default: Maximum number of nodes
       NodeGroupName:
         default: Node group name
       NodeVolumeSize:
@@ -75,8 +71,6 @@ Metadata:
         default: Additional EKS admin ARNs
       KubernetesVersion:
         default: Kubernetes version
-      ProvisionClusterAutoScaler:
-        default: Provision Kubernetes cluster auto-scaler
       LambdaZipsBucketName:
         default: Lambda zips bucket name
 Parameters:
@@ -253,10 +247,6 @@ Parameters:
     Default: 3
     Description: The number of Amazon EKS node instances. The default is one for each of the three Availability Zones.
     Type: Number
-  MaxNumberOfNodes:
-    Default: 3
-    Description: The maximum number of Amazon EKS node instances.
-    Type: Number
   NodeGroupName:
     Default: Default
     Description: The name for EKS node group.
@@ -270,11 +260,6 @@ Parameters:
     AllowedValues: [ "1.11", "1.10" ]
     Description: The Kubernetes control plane version.
     Default: "1.11"
-  ProvisionClusterAutoScaler:
-    Description: Specifies whether the Kubernetes cluster auto-scaler is provisioned
-    Type: String
-    AllowedValues: [ "Enabled", "Disabled" ]
-    Default: "Disabled"
   LambdaZipsBucketName:
     Description: '[OPTIONAL] The name of the S3 bucket where the Lambda .zip files should be placed. If you leave this parameter blank, an S3 bucket will be created.'
     Type: String
@@ -331,7 +316,7 @@ Resources:
         PrivateSubnet2ID: !GetAtt VPCStack.Outputs.PrivateSubnet2AID
         PrivateSubnet3ID: !GetAtt VPCStack.Outputs.PrivateSubnet3AID
         NumberOfNodes: !Ref NumberOfNodes
-        MaxNumberOfNodes: !Ref MaxNumberOfNodes
+        MaxNumberOfNodes: !Ref NumberOfNodes
         NodeGroupName: !Ref NodeGroupName
         NodeVolumeSize: !Ref NodeVolumeSize
         LambdaZipsBucketName: !Ref LambdaZipsBucketName
@@ -340,7 +325,7 @@ Resources:
         AdditionalEKSAdminArns: !Join [ ",", !Ref AdditionalEKSAdminArns ]
         VPCID: !GetAtt VPCStack.Outputs.VPCID
         KubernetesVersion: !Ref KubernetesVersion
-        ProvisionClusterAutoScaler: !Ref ProvisionClusterAutoScaler
+        ProvisionClusterAutoScaler: Disabled
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/amazon-eks-master.template.yaml
+++ b/templates/amazon-eks-master.template.yaml
@@ -24,10 +24,12 @@ Metadata:
         Parameters:
           - NodeInstanceType
           - NumberOfNodes
+          - MaxNumberOfNodes
           - NodeGroupName
           - NodeVolumeSize
           - AdditionalEKSAdminArns
           - KubernetesVersion
+          - ProvisionClusterAutoScaler
       - Label:
           default: AWS Quick Start configuration
         Parameters:
@@ -63,6 +65,8 @@ Metadata:
         default: Nodes instance type
       NumberOfNodes:
         default: Number of nodes
+      MaxNumberOfNodes:
+        default: Maximum number of nodes
       NodeGroupName:
         default: Node group name
       NodeVolumeSize:
@@ -71,6 +75,8 @@ Metadata:
         default: Additional EKS admin ARNs
       KubernetesVersion:
         default: Kubernetes version
+      ProvisionClusterAutoScaler:
+        default: Provision Kubernetes cluster auto-scaler
       LambdaZipsBucketName:
         default: Lambda zips bucket name
 Parameters:
@@ -247,6 +253,10 @@ Parameters:
     Default: 3
     Description: The number of Amazon EKS node instances. The default is one for each of the three Availability Zones.
     Type: Number
+  MaxNumberOfNodes:
+    Default: 3
+    Description: The maximum number of Amazon EKS node instances.
+    Type: Number
   NodeGroupName:
     Default: Default
     Description: The name for EKS node group.
@@ -260,6 +270,11 @@ Parameters:
     AllowedValues: [ "1.11", "1.10" ]
     Description: The Kubernetes control plane version.
     Default: "1.11"
+  ProvisionClusterAutoScaler:
+    Description: Specifies whether the Kubernetes cluster auto-scaler is provisioned
+    Type: String
+    AllowedValues: [ "Enabled", "Disabled" ]
+    Default: "Disabled"
   LambdaZipsBucketName:
     Description: '[OPTIONAL] The name of the S3 bucket where the Lambda .zip files should be placed. If you leave this parameter blank, an S3 bucket will be created.'
     Type: String
@@ -316,6 +331,7 @@ Resources:
         PrivateSubnet2ID: !GetAtt VPCStack.Outputs.PrivateSubnet2AID
         PrivateSubnet3ID: !GetAtt VPCStack.Outputs.PrivateSubnet3AID
         NumberOfNodes: !Ref NumberOfNodes
+        MaxNumberOfNodes: !Ref MaxNumberOfNodes
         NodeGroupName: !Ref NodeGroupName
         NodeVolumeSize: !Ref NodeVolumeSize
         LambdaZipsBucketName: !Ref LambdaZipsBucketName
@@ -324,6 +340,7 @@ Resources:
         AdditionalEKSAdminArns: !Join [ ",", !Ref AdditionalEKSAdminArns ]
         VPCID: !GetAtt VPCStack.Outputs.VPCID
         KubernetesVersion: !Ref KubernetesVersion
+        ProvisionClusterAutoScaler: !Ref ProvisionClusterAutoScaler
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -20,6 +20,7 @@ Metadata:
         Parameters:
           - NodeInstanceType
           - NumberOfNodes
+          - MaxNumberOfNodes
           - NodeGroupName
           - NodeVolumeSize
       - Label:
@@ -44,6 +45,8 @@ Metadata:
         default: Nodes Instance Type
       NumberOfNodes:
         default: Number of Nodes
+      MaxNumberOfNodes:
+        default: Maximum number of Nodes
       NodeGroupName:
         default: Node Group Name
       NodeVolumeSize:
@@ -167,8 +170,12 @@ Parameters:
     Description: Type of EC2 instance for the Node instances
     Type: String
   NumberOfNodes:
-    Default: '3'
+    Default: 3
     Description: Number of EKS node instances
+    Type: Number
+  MaxNumberOfNodes:
+    Default: 3
+    Description: The maximum number of Amazon EKS node instances.
     Type: Number
   NodeGroupName:
     Default: Default
@@ -513,7 +520,7 @@ Resources:
       DesiredCapacity: !Ref NumberOfNodes
       LaunchConfigurationName: !Ref NodeLaunchConfig
       MinSize: !Ref NumberOfNodes
-      MaxSize: !Ref NumberOfNodes
+      MaxSize: !Ref MaxNumberOfNodes
       VPCZoneIdentifier: [ !Ref PrivateSubnet1ID, !Ref PrivateSubnet2ID, !Ref PrivateSubnet3ID ]
       TargetGroupARNs: !If [ DisableTargetGroups, !Ref "AWS::NoValue", !Ref TargetGroupARNs ]
       Tags:
@@ -522,6 +529,9 @@ Resources:
           PropagateAtLaunch: true
         - Key: !Sub 'kubernetes.io/cluster/${EKSControlPlane}'
           Value: 'owned'
+          PropagateAtLaunch: true
+        - Key: k8s.io/cluster-autoscaler/enabled
+          Value: 'true'
           PropagateAtLaunch: true
     CreationPolicy:
       ResourceSignal:
@@ -661,3 +671,5 @@ Resources:
 Outputs:
   EKSNodeSecurityGroup:
     Value: !Ref NodeSecurityGroup
+  NodeAutoScalingGroup:
+    Value: !Ref NodeGroup

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -119,6 +119,9 @@ Parameters:
   NumberOfNodes:
     Default: 3
     Type: Number
+  MaxNumberOfNodes:
+    Default: 3
+    Type: Number
   NodeGroupName:
     Default: Default
     Type: String
@@ -146,6 +149,10 @@ Parameters:
     Type: String
     AllowedValues: [ "1.11", "1.10" ]
     Default: "1.11"
+  ProvisionClusterAutoScaler:
+    Type: String
+    AllowedValues: [ "Enabled", "Disabled" ]
+    Default: "Disabled"
   BootstrapArguments:
     Type: String
     Default: ""
@@ -181,6 +188,7 @@ Conditions:
   EnableBastion: !Equals [!Ref 'ProvisionBastionHost', 'Enabled']
   CustomBastionRole: !Not [!Equals [!Ref 'BastionIAMRoleName', '']]
   AdditionalVars: !Not [!Equals [!Ref 'BastionVariables', '']]
+  EnableClusterAutoScaler: !Equals [!Ref 'ProvisionClusterAutoScaler', 'Enabled']
 Resources:
   BastionStack:
     Condition: EnableBastion
@@ -224,6 +232,7 @@ Resources:
         VPCID: !Ref VPCID
         NodeInstanceType: !Ref NodeInstanceType
         NumberOfNodes: !Ref NumberOfNodes
+        MaxNumberOfNodes: !Ref MaxNumberOfNodes
         NodeGroupName: !Ref NodeGroupName
         NodeVolumeSize: !Ref NodeVolumeSize
         EKSControlPlane: !GetAtt EKSControlPlane.EKSName
@@ -264,6 +273,19 @@ Resources:
         VPCID: !Ref VPCID
         KubeConfigUploadRoleArn: !GetAtt IamStack.Outputs.KubeConfigUploadRoleArn
         CleanupLoadBalancersRoleArn: !GetAtt IamStack.Outputs.CleanupLoadBalancersRoleArn
+  ClusterAutoScalerStack:
+    Condition: EnableClusterAutoScaler
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/amazon-eks-cluster-autoscaler.template.yaml'
+      Parameters:
+        HelmLambdaArn: !GetAtt FunctionStack.Outputs.HelmLambdaArn
+        KubeConfigPath: !Sub "s3://${KubeConfigBucket}/.kube/config.enc"
+        KubeConfigKmsContext: !Ref KubeConfigKmsContext
+        NodeInstanceRoleName: !GetAtt IamStack.Outputs.NodeInstanceRoleName
+        NodeAutoScalingGroup: !GetAtt NodeGroupStack.Outputs.NodeAutoScalingGroup
+        EksClusterName: !GetAtt EKSControlPlane.EKSName
+        KubernetesVersion: !Ref KubernetesVersion
   LambdaZipsBucket:
     Type: AWS::S3::Bucket
     Condition: CreateLambdaZipsBucket


### PR DESCRIPTION
*Issue #, if available:* 20

*Description of changes:*

Added ProvisionClusterAutoScaler parameter to enable/disable (default) the provisioning of the cluster auto-scaler helm chart.

Added MaxNumberOfNodes parameter to set a maximum cluster size.

If enabled, a new nested stack is deployed that installs the official cluster auto-scaler helm chart using the appropriate version for the Kubernetes version selected by the user.

NOTE: The auto-scaler tag is always added to the worker nodes thus allowing the cluster auto-scaler to be added manually at a later date.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.