### PR TITLE
Expose TCP and X11 forwarding bastion options to main eks-template.

### DIFF
--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -179,6 +179,14 @@ Parameters:
   BastionIAMRoleName:
     Type: String
     Default: ""
+  BastionEnableTCPForwarding:
+    Type: String
+    Default: "false"
+    AllowedValues: [ "true", "false" ]
+  BastionEnableX11Forwarding:
+    Type: String
+    Default: "false"
+    AllowedValues: [ "true", "false" ]
   BastionVariables:
     Type: String
     Default: ""
@@ -211,6 +219,8 @@ Resources:
           - !Ref BastionBootstrapScript
         AlternativeIAMRole: !If [CustomBastionRole, !Ref BastionIAMRoleName, !GetAtt IamStack.Outputs.BastionRole]
         BastionAMIOS: !Ref BastionOS
+        EnableTCPForwarding: !Ref BastionEnableTCPForwarding
+        EnableX11Forwarding: !Ref BastionEnableX11Forwarding
         EnvironmentVariables: !Sub
         - >
           K8S_ROLE_ARN=${IamStack.Outputs.ControlPlaneProvisionRoleArn},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added BastionEnableTCPForwarding and BastionEnableX11Forwarding parameters to amazon-eks.template which in turn get passed onto underlying bastion template.

This opens the possibility for people to install the Kubernetes dashboard (and other monitoring tools) and setup an SSH tunnel from a local workstation to the cluster via the bastion host.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.