### PR TITLE
Allow to use dots(.) for the QSS3KeyPrefix parameter

### DIFF
--- a/templates/amazon-eks-functions.template.yaml
+++ b/templates/amazon-eks-functions.template.yaml
@@ -15,13 +15,13 @@ Parameters:
       or end with a hyphen (-).'
     Type: String
   QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
-    ConstraintDescription: 'Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), and forward slash (/).'
+    AllowedPattern: ^[0-9a-zA-Z-/.]*$
+    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
+      uppercase letters, hyphens (-), dots(.) and forward slash (/).
     Default: quickstart-amazon-eks/
-    Description: 'S3 key prefix for the Quick Start assets. Quick Start key prefix
-      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
-      forward slash (/).'
+    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), dots(.) and
+      forward slash (/).
     Type: String
   CopyZipsRoleArn:
     Type: String

--- a/templates/amazon-eks-iam.template.yaml
+++ b/templates/amazon-eks-iam.template.yaml
@@ -15,13 +15,13 @@ Parameters:
       or end with a hyphen (-).'
     Type: String
   QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
-    ConstraintDescription: 'Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), and forward slash (/).'
+    AllowedPattern: ^[0-9a-zA-Z-/.]*$
+    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
+      uppercase letters, hyphens (-), dots(.) and forward slash (/).
     Default: quickstart-amazon-eks/
-    Description: 'S3 key prefix for the Quick Start assets. Quick Start key prefix
-      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
-      forward slash (/).'
+    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), dots(.) and
+      forward slash (/).
     Type: String
   DeleteLambdaZipsBucketContents:
     Type: String

--- a/templates/amazon-eks-master-existing-cluster.template.yaml
+++ b/templates/amazon-eks-master-existing-cluster.template.yaml
@@ -21,12 +21,12 @@ Parameters:
       or end with a hyphen (-).
     Type: String
   QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    AllowedPattern: ^[0-9a-zA-Z-/.]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), and forward slash (/).
+      uppercase letters, hyphens (-), dots(.) and forward slash (/).
     Default: quickstart-amazon-eks/
     Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
-      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), dots(.) and
       forward slash (/).
     Type: String
   LambdaZipsBucketName:

--- a/templates/amazon-eks-master-existing-vpc.template.yaml
+++ b/templates/amazon-eks-master-existing-vpc.template.yaml
@@ -86,12 +86,12 @@ Parameters:
       or end with a hyphen (-).
     Type: String
   QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    AllowedPattern: ^[0-9a-zA-Z-/.]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), and forward slash (/).
+      uppercase letters, hyphens (-), dots(.) and forward slash (/).
     Default: quickstart-amazon-eks/
     Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
-      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), dots(.) and
       forward slash (/).
     Type: String
   RemoteAccessCIDR:

--- a/templates/amazon-eks-master.template.yaml
+++ b/templates/amazon-eks-master.template.yaml
@@ -133,12 +133,12 @@ Parameters:
       or end with a hyphen (-).
     Type: String
   QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    AllowedPattern: ^[0-9a-zA-Z-/.]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), and forward slash (/).
+      uppercase letters, hyphens (-), dots(.) and forward slash (/).
     Default: quickstart-amazon-eks/
     Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
-      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), dots(.) and
       forward slash (/).
     Type: String
   RemoteAccessCIDR:

--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -216,12 +216,12 @@ Parameters:
       or end with a hyphen (-).
     Type: String
   QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    AllowedPattern: ^[0-9a-zA-Z-/.]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), and forward slash (/).
+      uppercase letters, hyphens (-), dots(.) and forward slash (/).
     Default: quickstart-amazon-eks/
     Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
-      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), dots(.) and
       forward slash (/).
     Type: String
 Conditions:

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -19,10 +19,13 @@ Parameters:
     Default: aws-quickstart
     Type: String
   QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    AllowedPattern: ^[0-9a-zA-Z-/.]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), and forward slash (/).
+      uppercase letters, hyphens (-), dots(.) and forward slash (/).
     Default: quickstart-amazon-eks/
+    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), dots(.) and
+      forward slash (/).
     Type: String
   RemoteAccessCIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$


### PR DESCRIPTION
*Description of changes:*
Allow to use dots(.) so it is possible to create a prefix representing a version of these templates on S3, for example:

aws-quickstart/**1.0.0**/ where aws-quickstart is the QSS3BucketName and 1.0.0 is the QSS3KeyPrefix parameter.