### PR TITLE
Couldn't connect the control plane API server from bastion node

### DIFF
--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -260,7 +260,7 @@ Resources:
     Condition: EnableBastion
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
-      Description: Allow pods to communicate with the cluster API Server
+      Description: Allow SSH from Bastion server to Nodes
       GroupId: !GetAtt NodeGroupStack.Outputs.EKSNodeSecurityGroup
       SourceSecurityGroupId: !GetAtt BastionStack.Outputs.BastionSecurityGroupID
       IpProtocol: tcp

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -266,6 +266,16 @@ Resources:
       IpProtocol: tcp
       ToPort: 22
       FromPort: 22
+  BastionToAPIServerAccess:
+    Condition: EnableBastion
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      Description: Allow Bastion server to communicate with the cluster API Server
+      GroupId: !Ref ControlPlaneSecurityGroup
+      SourceSecurityGroupId: !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+      IpProtocol: tcp
+      ToPort: 443
+      FromPort: 443
   IamStack:
     Type: "AWS::CloudFormation::Stack"
     Properties:


### PR DESCRIPTION
Issue #, if available:
Issue 1:
After the CF stack created and if you disable API server public access, then we couldn't connect the k8s API server from bastion server. Looks the security group rule for that communication is missing.

Issue 2:
Description for SG rule (ssh access from bastion to nodes in nodegroup) is wrong.

Description of changes:
Added the rule in ControlPlane security group from bastion server.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
