### PR TITLE
Remove public ips from worker nodes

### DIFF
--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -690,7 +690,7 @@ Resources:
             b-bootstrap:
               command: !Sub /etc/eks/bootstrap.sh ${EKSControlPlane} ${BootstrapArguments}
     Properties:
-      AssociatePublicIpAddress: true
+      AssociatePublicIpAddress: false
       IamInstanceProfile: !Ref NodeInstanceProfile
       ImageId: !FindInMap
         - AWSAMIRegionMap


### PR DESCRIPTION
*Issue #, if available:*
- NodeGroup worker nodes are created under private subnets so it shouldn't require public IPs. But the nodegroup `EC2 Launch Configuration` attaching the public IPs for the worker nodes.

*Description of changes:*
- Updated the nodegroup `Launch Config` to disable the public IP assignment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
