### PR TITLE
Update kubelet.service

### DIFF
--- a/scripts/amazon-eks/kubelet.service
+++ b/scripts/amazon-eks/kubelet.service
@@ -11,8 +11,8 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --allow-privileged=true \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime docker \
-    --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
-
+    --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS \
+    --image-pull-progress-deadline=2m
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE
 RestartSec=5


### PR DESCRIPTION
I added this to the kubelet.service because on my cluster built off this quickstart even relatively small images saw this activity pulling from ECR:

```
  Normal   Scheduled  12m                default-scheduler                     Successfully assigned default/mycontainer-fd857b54f-w5p6c to ip-10-0-154-77.ec2.internal
  Warning  Failed     10m                kubelet, ip-10-0-154-77.ec2.internal  Failed to pull image "111111111.dkr.ecr.us-east-1.amazonaws.com/my/container:e87716617021afc0307a7537d74d3927f6cb9526: rpc error: code = Unknown desc = error pulling image configuration: Get https://prod-us-east-1-starport-layer-bucket.s3.amazonaws.com/***snip***dial tcp: i/o timeout
  Warning  Failed     10m                kubelet, ip-10-0-154-77.ec2.internal  Error: ErrImagePull
  Normal   BackOff    10m                kubelet, ip-10-0-154-77.ec2.internal  Back-off pulling image "111111111.dkr.ecr.us-east-1.amazonaws.com/my/container:e87716617021afc0307a7537d74d3927f6cb9526 
  Warning  Failed     10m                kubelet, ip-10-0-154-77.ec2.internal  Error: ImagePullBackOff
  Normal   Pulling    10m (x2 over 12m)  kubelet, ip-10-0-154-77.ec2.internal  pulling image "111111111.dkr.ecr.us-east-1.amazonaws.com/my/container:e87716617021afc0307a7537d74d3927f6cb9526 
  Normal   Pulled     2m56s              kubelet, ip-10-0-154-77.ec2.internal  Successfully pulled image "11111111.dkr.ecr.us-east-1.amazonaws.com/my/containere87716617021afc0307a7537d74d3927f6cb9526 
  Normal   Created    2m54s              kubelet, ip-10-0-154-77.ec2.internal  Created container
  Normal   Started    2m54s              kubelet, ip-10-0-154-77.ec2.internal  Started container
```

Adding a slightly longer --image-pull-progress-deadline allowed it to succeed on the first try for even somewhat larger containers.   I think given that ECR is likely to be a frequent place users of this are going to want to pull containers for bumping this up as a default would help.   The container in the logs above weighs in at 300mb, so it's larger but not extreme for many workloads.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
