### PR TITLE
CleanupLoadBalancers can now handle more than 20 Load Balancers

### DIFF
--- a/functions/source/CleanupLoadBalancers/lambda_function.py
+++ b/functions/source/CleanupLoadBalancers/lambda_function.py
@@ -59,11 +59,15 @@ def delete_handler(event, _):
                 break
         lbs_to_remove = []
         if lbs:
-            lbs = elb.describe_tags(**{lt[2]: lbs})["TagDescriptions"]
-            for tags in lbs:
-                for tag in tags['Tags']:
-                    if tag["Key"] == tag_key and tag['Value'] == "owned":
-                        lbs_to_remove.append(tags[lt[4]])
+            #Split LB list into groups of 'size' items.
+            size = 20
+            lb_groups = (lbs[pos:pos + size] for pos in range(0, len(lbs), size))
+            for lb_group in lb_groups:
+                lb_group = elb.describe_tags(**{lt[2]: lb_group})["TagDescriptions"]
+                for tags in lb_group:
+                    for tag in tags['Tags']:
+                        if tag["Key"] == tag_key and tag['Value'] == "owned":
+                            lbs_to_remove.append(tags[lt[4]])
         if lbs_to_remove:
             for lb in lbs_to_remove:
                 print("removing elb %s" % lb)


### PR DESCRIPTION
*Description of changes:*

The current version of this Quickstart does not terminate correctly if the current region has more than 20 Load Balancers.

The CleanupLoadBalancers Lambda function attempts to run a DescribeTags() on the active Load Balancers, however DescribeTags() is limited to 20 Load Balancers at a time.

Currently, the Lambda function sends all active Load Balancers into the DescribeTags() API call which can trigger a validation error if there are more than 20 Load Balancers in the current region. The deletion of the Quickstart CloudFormation Stacks will fail.

This Pull Request will allow the Lambda function to split the list of active Load Balancers into groups of 20, and supply each group into separate DescribeTags() API calls. This ensures that we do not exceed the 20 LB limit for the DescribeTags() API call.

I have tested this solution in my own account and can confirm from my CloudTrail Events that the LBs are being split into separate groups for DescribeTags() as expected. My CloudFormation Stacks also can now delete successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
