### PR TITLE
Fixed Custom Bastion role unable to access EKS cluster

### DIFF
--- a/templates/amazon-eks-iam.template.yaml
+++ b/templates/amazon-eks-iam.template.yaml
@@ -36,9 +36,13 @@ Parameters:
     Type: String
     Default: "Enabled"
     AllowedValues: ["Enabled", "Disabled"]
+  BastionIAMRoleName:
+    Type: String
+    Default: ""
 Conditions:
   CreateDeleteBucketContentsRole: !Equals [!Ref 'DeleteLambdaZipsBucketContents', "True"]
   EnableBastionRole: !Equals [!Ref CreateBastionRole, "Enabled"]
+  CustomBastionRole: !Not [!Equals [!Ref 'BastionIAMRoleName', '']]
 Resources:
   DeleteBucketContentsRole:
     Condition: CreateDeleteBucketContentsRole
@@ -103,6 +107,13 @@ Resources:
             - Effect: Allow
               Principal:
                 AWS: !GetAtt BastionRole.Arn
+              Action: sts:AssumeRole
+            - !Ref AWS::NoValue
+          - !If
+            - CustomBastionRole
+            - Effect: Allow
+              Principal:
+                AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${BastionIAMRoleName}'
               Action: sts:AssumeRole
             - !Ref AWS::NoValue
           - Effect: Allow

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -279,6 +279,7 @@ Resources:
         BootstrapArguments: !Ref BootstrapArguments
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        CleanupSecurityGroupDependenciesLambdaArn: !GetAtt FunctionStack.Outputs.CleanupSecurityGroupDependenciesLambdaArn
   BastionSShToNodes:
     Condition: EnableBastion
     Type: "AWS::EC2::SecurityGroupIngress"
@@ -310,6 +311,7 @@ Resources:
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         KubeConfigBucket: !Ref KubeConfigBucket
         CreateBastionRole: !If [CustomBastionRole, "Disabled", !If [EnableBastion, "Enabled", "Disabled"]]
+        BastionIAMRoleName: !If [CustomBastionRole, !Ref BastionIAMRoleName , ''] 
   FunctionStack:
     Type: "AWS::CloudFormation::Stack"
     Properties:
@@ -467,3 +469,7 @@ Outputs:
     Value: !GetAtt IamStack.Outputs.NodeInstanceRoleArn
   CleanupSecurityGroupDependenciesLambdaArn:
     Value: !GetAtt FunctionStack.Outputs.CleanupSecurityGroupDependenciesLambdaArn
+  NodeAutoScalingGroup:
+    Value: !GetAtt NodeGroupStack.Outputs.NodeAutoScalingGroup
+  ControlPlaneProvisionRoleArn:
+    Value: !GetAtt IamStack.Outputs.ControlPlaneProvisionRoleArn


### PR DESCRIPTION
1) exposed the controlplane provision role arn in EKSSTACK 2) added policy based on custombastionrole condition 3) exposed the nodegroup ASG name

*Issue #, if available:*  EKS is created ControlPlaneProvisionRole. default bastion role has authorization to assume ControlPlaneProvisionRole to communicate with EKS cluster.
I used custom bastion role, This new custom role is not given sts Assume role access to the ControlPlaneProvisionRole automatically. Thus my bastion host is unable to communicate with EKS cluster.

*Description of changes:*
I added CustomBastionRole condition to iam stack, if it is true then it will add a policy to ControlPlaneProvisionRole which will allow my custom role to be able to assume ControlPlaneProvisionRole .
exposed ControlPlaneProvisionRole and nodegroupASG name, I need them for my quickstart cloudformation template  deveopment which is using EKS QS as submodule.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
