### PR TITLE
Enable Prometheus in EKS cluster

### DIFF
--- a/ci/amazon-eks-prometheus.json
+++ b/ci/amazon-eks-prometheus.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "override"
+  },
+  {
+    "ParameterKey": "RemoteAccessCIDR",
+    "ParameterValue": "10.0.0.0/16"
+  },
+  {
+    "ParameterKey": "AvailabilityZones",
+    "ParameterValue": "$[taskcat_genaz_3]"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "AdditionalEKSAdminArns",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "Prometheus",
+    "ParameterValue": "Enabled"
+  }
+]

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -29,3 +29,8 @@ tests:
     template_file: amazon-eks-master.template.yaml
     regions:
       - eu-central-1
+  quickstart-amazon-eks-prometheus:
+    parameter_input: amazon-eks-prometheus.json
+    template_file: amazon-eks-master.template.yaml
+    regions:
+      - ap-southeast-2

--- a/templates/amazon-eks-master.template.yaml
+++ b/templates/amazon-eks-master.template.yaml
@@ -46,6 +46,7 @@ Metadata:
           - EfsPerformanceMode
           - EfsThroughputMode
           - EfsProvisionedThroughputInMibps
+          - Prometheus
       - Label:
           default: AWS Quick Start configuration
         Parameters:
@@ -103,6 +104,8 @@ Metadata:
         default: EFS throughput mode
       EfsProvisionedThroughputInMibps:
         default: EFS provisioned throughput in Mibps
+      Prometheus:
+        default: Monitoring with Prometheus
 Parameters:
   AvailabilityZones:
     Description: The list of Availability Zones to use for the subnets in the VPC. Three
@@ -323,6 +326,11 @@ Parameters:
     MinValue: 0
     Default: 0
     Description: Set to 0 if EfsThroughputMode is set to bursting. Only has an effect when EfsStorageClass is enabled.
+  Prometheus:
+    Type: String
+    AllowedValues: [ Enabled, Disabled ]
+    Default: Disabled
+    Description: Choose Enabled to enable Monitoring with Prometheus
 Rules:
   EKSSupport:
     Assertions:
@@ -389,6 +397,7 @@ Resources:
         EfsPerformanceMode: !Ref EfsPerformanceMode
         EfsThroughputMode: !Ref EfsThroughputMode
         EfsProvisionedThroughputInMibps: !Ref EfsProvisionedThroughputInMibps
+        ProvisionPrometheus: !Ref Prometheus
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/amazon-eks-prometheus.template.yaml
+++ b/templates/amazon-eks-prometheus.template.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Deploys the prometheus helm chart into an existing kubernetes cluster"
+Parameters:
+  HelmLambdaArn:
+    Type: String
+  KubeConfigPath:
+    Type: String
+  KubeConfigKmsContext:
+    Type: String
+    Default: "EKSQuickStart"
+  EksClusterName:
+    Type: String
+Resources:
+  # Install prometheus helm chart
+  PrometheusHelmChart:
+    Type: "Custom::Helm"
+    Version: "1.0"
+    Properties:
+      ServiceToken: !Ref HelmLambdaArn
+      KubeConfigPath: !Ref KubeConfigPath
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      Namespace: prometheus
+      Chart: stable/prometheus
+      Name: prometheus
+      Values:
+        server.persistentVolume.storageClass: "gp2"
+        server.statefulSet.enabled: true
+        server.replicaCount: 2
+        server.service.sessionAffinity: ClientIP
+        alertmanager.persistentVolume.storageClass: "gp2"
+        alertmanager.statefulSet.enabled: true
+        alertmanager.replicaCount: 2
+Outputs:
+  PrometheusReleaseName:
+    Value: !Ref PrometheusHelmChart

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -145,6 +145,10 @@ Parameters:
     Type: String
     AllowedValues: [ "Enabled", "Disabled" ]
     Default: "Disabled"
+  ProvisionPrometheus:
+    Type: String
+    AllowedValues: [ "Enabled", "Disabled" ]
+    Default: "Disabled"
   BootstrapArguments:
     Type: String
     Default: ""
@@ -205,6 +209,7 @@ Conditions:
   CustomBastionRole: !Not [!Equals [!Ref 'BastionIAMRoleName', '']]
   AdditionalVars: !Not [!Equals [!Ref 'BastionVariables', '']]
   EnableClusterAutoScaler: !Equals [!Ref 'ProvisionClusterAutoScaler', 'Enabled']
+  EnablePrometheus: !Equals [!Ref 'ProvisionPrometheus', 'Enabled']
   EnableEfs: !Equals [!Ref 'EfsStorageClass', 'Enabled']
 Resources:
   BastionEksPermissions:
@@ -431,6 +436,16 @@ Resources:
       }
   KubeConfigBucket:
     Type: "AWS::S3::Bucket"
+  PrometheusStack:
+    Condition: EnablePrometheus
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/amazon-eks-prometheus.template.yaml'
+      Parameters:
+        HelmLambdaArn: !GetAtt FunctionStack.Outputs.HelmLambdaArn
+        KubeConfigPath: !Sub "s3://${KubeConfigBucket}/.kube/config.enc"
+        KubeConfigKmsContext: !Ref KubeConfigKmsContext
+        EksClusterName: !GetAtt EKSControlPlane.EKSName
 Outputs:
   KubeConfigPath:
     Value: !Sub "s3://${KubeConfigBucket}/.kube/config.enc"


### PR DESCRIPTION
Enable Prometheus for monitoring (using Prometheus Helm chart)

### Monitoring Components:
- [Prometheus](https://prometheus.io/): installed as a StatefulSet with 2 replicas that uses Persistent Volumes with EBS (i.e. 2 EBS volumes)
- [Alertmanager](https://github.com/prometheus/alertmanager): installed as a StatefulSet with 2 replicas that uses Persistent Volumes with EBS (i.e. 2 EBS volumes)
- [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics): installed as a Deployment
- [node-exporter](https://github.com/prometheus/node_exporter): installed as a DaemonSet.
- [pushgateway](https://github.com/prometheus/pushgateway): installed as a Deployment

### Access Prometheus Server
`export POD_NAME=$(kubectl get pods --namespace prometheus -l "app=prometheus,component=server" -o jsonpath="{.items[0].metadata.name}")`

`kubectl --namespace prometheus port-forward $POD_NAME 8080:9090`

### Access Alertmanager
`export POD_NAME=$(kubectl get pods --namespace prometheus -l "app=prometheus,component=alertmanager" -o jsonpath="{.items[0].metadata.name}")`

`kubectl --namespace prometheus port-forward $POD_NAME 8090:9093`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.