### PR TITLE
Enable Monitoring Stack with Prometheus & Grafana

### DIFF
--- a/ci/amazon-eks-monitoring-prom-graf.json
+++ b/ci/amazon-eks-monitoring-prom-graf.json
@@ -20,7 +20,7 @@
     "ParameterValue": ""
   },
   {
-    "ParameterKey": "Prometheus",
-    "ParameterValue": "Enabled"
+    "ParameterKey": "MonitoringStack",
+    "ParameterValue": "Prometheus + Grafana"
   }
 ]

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -29,8 +29,8 @@ tests:
     template_file: amazon-eks-master.template.yaml
     regions:
       - eu-central-1
-  quickstart-amazon-eks-prometheus:
-    parameter_input: amazon-eks-prometheus.json
+  quickstart-amazon-eks-monitoring-prom-graf:
+    parameter_input: amazon-eks-monitoring-prom-graf.json
     template_file: amazon-eks-master.template.yaml
     regions:
       - ap-southeast-2

--- a/templates/amazon-eks-grafana.template.yaml
+++ b/templates/amazon-eks-grafana.template.yaml
@@ -1,0 +1,69 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Deploys the grafana helm chart into an existing kubernetes cluster"
+Parameters:
+  HelmLambdaArn:
+    Type: String
+  KubeConfigPath:
+    Type: String
+  KubeConfigKmsContext:
+    Type: String
+    Default: "EKSQuickStart"
+  EksClusterName:
+    Type: String
+  VPCCIDR:
+    Default: 10.0.0.0/16
+    Description: The CIDR block for the VPC
+    Type: String  
+Resources:
+  # Install grafana helm chart
+  GrafanaHelmChart:
+    Type: "Custom::Helm"
+    Version: "1.0"
+    Properties:
+      ServiceToken: !Ref HelmLambdaArn
+      KubeConfigPath: !Ref KubeConfigPath
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      Namespace: grafana
+      Chart: stable/grafana
+      Name: grafana
+      ValueYaml: |
+        persistence:
+          type: pvc
+          enabled: true
+          storageClassName: gp2
+        service:
+          type: LoadBalancer
+        datasources:
+          datasources.yaml:
+            apiVersion: 1
+            datasources:
+            - name: Prometheus
+              type: prometheus
+              url: http://prometheus-server.prometheus.svc.cluster.local
+              access: proxy
+              isDefault: true
+        dashboardProviders:
+          dashboardproviders.yaml:
+            apiVersion: 1
+            providers:
+            - name: 'default'
+              orgId: 1
+              folder: ''
+              type: file
+              disableDeletion: false
+              editable: true
+              options:
+                path: /var/lib/grafana/dashboards/default
+        dashboards:
+          default:
+            all-nodes:
+              gnetId: 3131
+              revision: 1
+              datasource: Prometheus
+            all-pods:
+              gnetId: 3146
+              revision: 1
+              datasource: Prometheus
+Outputs:
+  GrafanaReleaseName:
+    Value: !Ref GrafanaHelmChart

--- a/templates/amazon-eks-master.template.yaml
+++ b/templates/amazon-eks-master.template.yaml
@@ -46,7 +46,7 @@ Metadata:
           - EfsPerformanceMode
           - EfsThroughputMode
           - EfsProvisionedThroughputInMibps
-          - Prometheus
+          - MonitoringStack
       - Label:
           default: AWS Quick Start configuration
         Parameters:
@@ -104,8 +104,8 @@ Metadata:
         default: EFS throughput mode
       EfsProvisionedThroughputInMibps:
         default: EFS provisioned throughput in Mibps
-      Prometheus:
-        default: Monitoring with Prometheus
+      MonitoringStack:
+        default: Monitoring Stack
 Parameters:
   AvailabilityZones:
     Description: The list of Availability Zones to use for the subnets in the VPC. Three
@@ -326,11 +326,11 @@ Parameters:
     MinValue: 0
     Default: 0
     Description: Set to 0 if EfsThroughputMode is set to bursting. Only has an effect when EfsStorageClass is enabled.
-  Prometheus:
+  MonitoringStack:
     Type: String
-    AllowedValues: [ Enabled, Disabled ]
-    Default: Disabled
-    Description: Choose Enabled to enable Monitoring with Prometheus
+    AllowedValues: [ "Prometheus + Grafana", "None" ]
+    Default: "None"
+    Description: Enable Monitoring stack with "Prometheus+Grafana"
 Rules:
   EKSSupport:
     Assertions:
@@ -397,7 +397,7 @@ Resources:
         EfsPerformanceMode: !Ref EfsPerformanceMode
         EfsThroughputMode: !Ref EfsThroughputMode
         EfsProvisionedThroughputInMibps: !Ref EfsProvisionedThroughputInMibps
-        ProvisionPrometheus: !Ref Prometheus
+        ProvisionMonitoringStack: !Ref MonitoringStack
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -145,10 +145,10 @@ Parameters:
     Type: String
     AllowedValues: [ "Enabled", "Disabled" ]
     Default: "Disabled"
-  ProvisionPrometheus:
+  ProvisionMonitoringStack:
     Type: String
-    AllowedValues: [ "Enabled", "Disabled" ]
-    Default: "Disabled"
+    AllowedValues: [ "Prometheus + Grafana", "None" ]
+    Default: "None"
   BootstrapArguments:
     Type: String
     Default: ""
@@ -209,7 +209,7 @@ Conditions:
   CustomBastionRole: !Not [!Equals [!Ref 'BastionIAMRoleName', '']]
   AdditionalVars: !Not [!Equals [!Ref 'BastionVariables', '']]
   EnableClusterAutoScaler: !Equals [!Ref 'ProvisionClusterAutoScaler', 'Enabled']
-  EnablePrometheus: !Equals [!Ref 'ProvisionPrometheus', 'Enabled']
+  EnableMonitoringPrometheusGrafana: !Equals [!Ref 'ProvisionMonitoringStack', 'Prometheus + Grafana']
   EnableEfs: !Equals [!Ref 'EfsStorageClass', 'Enabled']
 Resources:
   BastionEksPermissions:
@@ -437,7 +437,7 @@ Resources:
   KubeConfigBucket:
     Type: "AWS::S3::Bucket"
   PrometheusStack:
-    Condition: EnablePrometheus
+    Condition: EnableMonitoringPrometheusGrafana
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub 'https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/amazon-eks-prometheus.template.yaml'
@@ -446,6 +446,17 @@ Resources:
         KubeConfigPath: !Sub "s3://${KubeConfigBucket}/.kube/config.enc"
         KubeConfigKmsContext: !Ref KubeConfigKmsContext
         EksClusterName: !GetAtt EKSControlPlane.EKSName
+  GrafanaStack:
+    Condition: EnableMonitoringPrometheusGrafana
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/amazon-eks-grafana.template.yaml'
+      Parameters:
+        HelmLambdaArn: !GetAtt FunctionStack.Outputs.HelmLambdaArn
+        KubeConfigPath: !Sub "s3://${KubeConfigBucket}/.kube/config.enc"
+        KubeConfigKmsContext: !Ref KubeConfigKmsContext
+        EksClusterName: !GetAtt EKSControlPlane.EKSName
+        VPCCIDR: !Ref VPCID
 Outputs:
   KubeConfigPath:
     Value: !Sub "s3://${KubeConfigBucket}/.kube/config.enc"


### PR DESCRIPTION
### Enable Monitoring stack with Prometheus (for Metrics collection) and Grafana (for Visualization).

- Prometheus and Grafana is installed via helm charts. Grafana can be accessed by ELB.
- grafana is pre-populated with some useful dashboards like [Kubernetes All Nodes](https://grafana.com/grafana/dashboards/3131) and [Kubernetes Pods](https://grafana.com/grafana/dashboards/3146). Just after installation, you can monitor current node/pod utilization, which is collected by Prometheus
- grafana is configured with Prometheus as default data source
- _Access Grafana Dashboard:_
1. Get your 'admin' user password by running:

`kubectl get secret --namespace grafana grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo`

2. Get ELB URL created for Grafana: 
`kubectl get svc --namespace grafana grafana -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'`

3. Login with the password from step 1 and the username: admin
