### PR TITLE
Update Output for NodeGroupSecurityGroup

### DIFF
--- a/templates/amazon-eks-master-existing-vpc.template.yaml
+++ b/templates/amazon-eks-master-existing-vpc.template.yaml
@@ -351,4 +351,4 @@ Outputs:
   BastionSecurityGroup:
     Value: !GetAtt EKSStack.Outputs.BastionSecurityGroup
   NodeGroupSecurityGroup:
-    Value: !GetAtt EKSStack.Outputs.EKSNodeSecurityGroup
+    Value: !GetAtt EKSStack.Outputs.NodeGroupSecurityGroup


### PR DESCRIPTION
EKSStack template Outputs a value of NodeGroupSecurityGroup instead of EKSNodeSecurityGroup

*Issue #87:*

*Updated the Output of the existing vpc template to us the proper NodeGroupSecurity group from the EKSStack:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
