### PR TITLE
Expose Custom AMI ID in EKS Template

### DIFF
--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -125,6 +125,9 @@ Parameters:
   NodeVolumeSize:
     Default: 20
     Type: String
+  CustomAmiId:
+    Default: ""
+    Type: String
   ManagedNodeGroup:
     AllowedValues: [ "yes", "no" ]
     Default: "no"
@@ -312,6 +315,7 @@ Resources:
         MaxNumberOfNodes: !Ref MaxNumberOfNodes
         NodeGroupName: !Ref NodeGroupName
         NodeVolumeSize: !Ref NodeVolumeSize
+        CustomAmiId: !Ref CustomAmiId
         ManagedNodeGroup: !Ref ManagedNodeGroup
         ManagedNodeGroupAMIType: !Ref ManagedNodeGroupAMIType
         EKSControlPlane: !GetAtt EKSControlPlane.EKSName


### PR DESCRIPTION
*Issue #, if available:*
#16 

*Description of changes:*
As a follow up on #16, this PR exposes `CustomAmiId` in the EKS template.

We use the EKS template to create the EKS cluster. The EKS template also creates the "initial" group of EKS nodes by calling the node group template. The node group template supports `CustomAmiId`, but the same parameter was not exposed in the EKS template. Now it is!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
