### PR TITLE
Remove repeated parameter

### DIFF
--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -18,6 +18,7 @@ Metadata:
       - Label:
           default: EKS Configuration
         Parameters:
+          - EKSControlPlane
           - NodeInstanceType
           - NumberOfNodes
           - MaxNumberOfNodes
@@ -47,6 +48,8 @@ Metadata:
         default: Private Subnet 3 ID
       VPCID:
         default: VPC ID
+      EKSControlPlane:
+        defualt: Eks Control plane name
       NodeInstanceType:
         default: Nodes Instance Type
       NumberOfNodes:
@@ -605,7 +608,7 @@ Mappings:
       SLES15EKS113: ami-0772af912976aa692
       SLES15EKS113GPU: ami-0772af912976aa692
       SLES15EKS112: ami-0772af912976aa692
-      SLES15EKS112GPU: ami-0772af912976aa692  
+      SLES15EKS112GPU: ami-0772af912976aa692
     us-east-1:
       AMZNEKS114: ami-08ac00d99a673bad0
       AMZNEKS114GPU: ami-000dbfddbb743f0a3
@@ -989,7 +992,7 @@ Resources:
       DependsOn: !If [ CleanupSGs, !Ref CleanupSecurityGroupDependencies, !Ref "AWS::NoValue" ]
     Condition: EnableManagedNodeGroup
     Properties:
-      ClusterName: !Ref EKSClusterName
+      ClusterName: !Ref EKSControlPlane
       NodeRole: !GetAtt NodeInstanceRole.Arn
       AmiType: !If [ EnableManagedNodeGroup, !Ref 'ManagedNodeGroupAMIType', !Ref "AWS::NoValue" ]
       InstanceTypes:

--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -271,8 +271,6 @@ Parameters:
     Type: String
     AllowedValues: [ "1.14", "1.13", "1.12" ]
     Default: "1.14"
-  EKSClusterName:
-    Type: String
   TargetGroupARNs:
     Type: CommaDelimitedList
     Default: ""

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -332,7 +332,6 @@ Resources:
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         QSS3BucketRegion: !Ref QSS3BucketRegion
-        EKSClusterName: !GetAtt EKSControlPlane.EKSName
         CleanupSecurityGroupDependenciesLambdaArn: !GetAtt FunctionStack.Outputs.CleanupSecurityGroupDependenciesLambdaArn
         KubeManifestLambdaArn: !GetAtt FunctionStack.Outputs.KubeManifestLambdaArn
         KubeConfigPath: !Sub "s3://${KubeConfigBucket}/.kube/config.enc"


### PR DESCRIPTION
*Issue #, if available:*

When the EKSClusterName was added it broke other templates calling the NodeGroup. This parameter is also not needed, as the template already requires the EKSControlPlane. 

*Description of changes:*

The EKSControlPlane name to be more descriptive, however, this will minimize the amount of repeat params.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
