### PR TITLE
update ALB Ingress Controller version

### DIFF
--- a/templates/amazon-eks-alb-ingress.template.yaml
+++ b/templates/amazon-eks-alb-ingress.template.yaml
@@ -121,6 +121,22 @@ Resources:
             Action:
             - waf:GetWebACL
             Resource: "*"
+          - Effect: Allow
+            Action:
+            - wafv2:GetWebACL
+            - wafv2:GetWebACLForResource
+            - wafv2:AssociateWebACL
+            - wafv2:DisassociateWebACL
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - shield:DescribeProtection
+            - shield:GetSubscriptionState
+            - shield:DeleteProtection
+            - shield:CreateProtection
+            - shield:DescribeSubscription
+            - shield:ListProtections
+            Resource: "*"
       Path: "/"
   ALBClusterRole:
     Type: "Custom::KubeManifest"
@@ -235,7 +251,7 @@ Resources:
                    args:
                      - --ingress-class=alb
                      - !Sub "--cluster-name=${ClusterName}"
-                   image: docker.io/amazon/aws-alb-ingress-controller:v1.1.4
+                   image: docker.io/amazon/aws-alb-ingress-controller:v1.1.7
                serviceAccountName: alb-ingress-controller
 
 Outputs:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/1131

*Description of changes:*
The current version of alb ingress controller has trouble cleaning up target groups and registering targets. This PR updates the controller version to latest with the updated IAM requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
