### PR TITLE
Do not stabilize cronjobs

### DIFF
--- a/functions/source/KubeManifest/lambda_function.py
+++ b/functions/source/KubeManifest/lambda_function.py
@@ -259,7 +259,7 @@ def create_handler(event, _):
         return physical_resource_id
     outp = run_command("kubectl create --save-config -o json -f %s" % manifest_file)
     helper.Data = build_output(json.loads(outp))
-    if helper.Data["selfLink"].startswith('/apis/batch'):
+    if helper.Data["selfLink"].startswith('/apis/batch') and 'cronjobs' not in helper.Data["selfLink"]:
         stabilize_job(helper.Data["namespace"], helper.Data["name"])
     return helper.Data["selfLink"]
 


### PR DESCRIPTION
*Description of changes:*
This PR fixes stabilize_job function from KubeManifest lambda. For cronjobs ‘selfLink’ looks like this: 
`"selfLink": "/apis/batch/v1beta1/namespaces/airflow/cronjobs/airflow"`

I assume that we don't want to stabilize cronjob because it can be executed at any time and we shouldn't wait for its completion.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
