### PR TITLE
Fixed missing ClusterName property

### DIFF
--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -931,6 +931,7 @@ Resources:
       ServiceToken: !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:EKS-QuickStart-KubeManifest-${EKSControlPlane}"
       HttpProxy: !Ref HttpProxy
       VpcId: !Ref VPCID
+      ClusterName: !Ref EKSControlPlane
   NodeLaunchConfig:
     Condition: DisableManagedNodeGroup
     Type: AWS::AutoScaling::LaunchConfiguration


### PR DESCRIPTION
*Issue:*
Exception while creating CloudFormation Stack 

```
"exception": "Traceback (most recent call last):\n  File \"/opt/python/crhelper/resource_helper.py\", line 202, in _wrap_function\n    self.PhysicalResourceId = func(self._event, self._context) if func else ''\n  File \"/var/task/lambda_function.py\", line 257, in create_handler\n    physical_resource_id,  manifest_file = handler_init(event)\n  File \"/var/task/lambda_function.py\", line 218, in handler_init\n    create_kubeconfig(event['ResourceProperties']['ClusterName'])\nKeyError: 'ClusterName'
```

Description of changes:
- `create_kubeconfig` function part of `KubeManifest` custom resource is failing with above error. i.e, `ClusterName` key not found.
- As part of this pull request, `amazon-eks-nodegroup` will pass `ClusterName` key while invoking the Lambda.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
