### PR TITLE
set proxy env vars for KubeManifest resource

### DIFF
--- a/templates/amazon-eks-functions.template.yaml
+++ b/templates/amazon-eks-functions.template.yaml
@@ -63,11 +63,15 @@ Parameters:
     Type: List<String>
   EKSClusterName:
     Type: String
+  HttpProxy:
+    Type: String
+    Default: ""
 Conditions:
   CreateDeleteBucketContentsLambda: !Equals
     - !Ref 'DeleteLambdaZipsBucketContents'
     - "True"
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
+  NoProxy: !Equals [!Ref HttpProxy, '']
 Resources:
   CopyZips:
     Type: Custom::CopyZips
@@ -309,7 +313,11 @@ Resources:
       Code:
         S3Bucket: !Ref LambdaZipsBucketName
         S3Key: !Sub '${QSS3KeyPrefix}functions/packages/KubeManifest/lambda.zip'
-      Environment: { Variables: { KUBECONFIG: /tmp/.kube/config } }
+      Environment:
+        Variables:
+          KUBECONFIG: /tmp/.kube/config
+          HTTPS_PROXY: !If [NoProxy, !Ref 'AWS::NoValue', !Ref HttpProxy]
+          HTTP_PROXY: !If [NoProxy, !Ref 'AWS::NoValue', !Ref HttpProxy]
       VpcConfig:
         SecurityGroupIds: [!Ref EKSLambdaSecurityGroup]
         SubnetIds: !Ref EKSSubnetIds

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -474,6 +474,7 @@ Resources:
             - !Join [",", [ !Ref PrivateSubnet1ID, !Ref PrivateSubnet2ID ]]
             - !Ref PrivateSubnet1ID
         EKSClusterName: !If [GenerateClusterName, !Ref GenerateName, !Ref EKSClusterName]
+        HttpProxy: !Ref HttpProxy
   ClusterAutoScalerStack:
     Condition: EnableClusterAutoScaler
     Metadata:


### PR DESCRIPTION
*Issue #, if available:* Fixes #164

*Description of changes:*

Sets proxy env var on KubeManifest resource so that `aws eks update-kubeconfig` call can pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
