### PR TITLE
Adding output for NodeSGFunctionArn

### DIFF
--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -755,3 +755,5 @@ Outputs:
     Value: !GetAtt NodeGroupStack.Outputs.NodeAutoScalingGroup
   OIDCIssuerURL:
     Value : !GetAtt EKSControlPlane.Outputs.OIDCIssuerURL
+  NodeSGFunctionArn:
+    Value : !GetAtt FunctionStack.Outputs.NodeSGFunctionArn


### PR DESCRIPTION
*Description of changes:*
When a node group is built outside of the EKS deployment, the NodeSGFunctionArn is needed as a parameter input.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
