### PR TITLE
Adding windows nodegroup support

### DIFF
--- a/scripts/windows-setup.sh
+++ b/scripts/windows-setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+echo ${AWS_REGION}
+yum install -y jq  && yum install -y openssl
+curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+mv ./kubectl /usr/bin/kubectl
+kubectl apply -f https://amazon-eks.s3.us-west-2.amazonaws.com/manifests/${AWS_REGION}/vpc-resource-controller/latest/vpc-resource-controller.yaml
+curl -o webhook-create-signed-cert.sh https://amazon-eks.s3.us-west-2.amazonaws.com/manifests/${AWS_REGION}/vpc-admission-webhook/latest/webhook-create-signed-cert.sh
+curl -o webhook-patch-ca-bundle.sh https://amazon-eks.s3.us-west-2.amazonaws.com/manifests/${AWS_REGION}/vpc-admission-webhook/latest/webhook-patch-ca-bundle.sh
+curl -o vpc-admission-webhook-deployment.yaml https://amazon-eks.s3.us-west-2.amazonaws.com/manifests/${AWS_REGION}/vpc-admission-webhook/latest/vpc-admission-webhook-deployment.yaml
+chmod +x webhook-create-signed-cert.sh webhook-patch-ca-bundle.sh
+./webhook-create-signed-cert.sh
+mkdir -p ~/.kube;
+cat > ~/.kube/config <<EOF
+  apiVersion: v1
+  clusters:
+  - cluster:
+      server: ${K8S_ENDPOINT}
+      certificate-authority-data: ${K8S_CA_DATA}
+    name: kubernetes
+  contexts:
+  - context:
+      cluster: kubernetes
+      user: aws
+    name: aws
+  current-context: aws
+  kind: Config
+  preferences: {}
+  users:
+  - name: aws
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1alpha1
+        command: aws-iam-authenticator
+        args:
+          - "token"
+          - "-i"
+          - "${K8S_CLUSTER_NAME}"
+EOF
+cat ./vpc-admission-webhook-deployment.yaml | ./webhook-patch-ca-bundle.sh > vpc-admission-webhook.yaml
+rm -rf ~/.kube/config
+kubectl apply -f vpc-admission-webhook.yaml

--- a/templates/amazon-eks-controlplane.template.yaml
+++ b/templates/amazon-eks-controlplane.template.yaml
@@ -12,6 +12,8 @@ Parameters:
     Type: String
   NodeInstanceRoleArn:
     Type: String
+  WindowsNodeInstanceRoleArn:
+    Type: String
   CleanupLoadBalancersLambdaArn:
     Type: String
   GetCallerArnLambdaArn:
@@ -62,6 +64,7 @@ Conditions:
   AddUser: !Not [ !Equals [ !Ref AdditionalEKSAdminUserArn, "" ] ]
   AddRole: !Not [ !Equals [ !Ref AdditionalEKSAdminRoleArn, "" ] ]
   BastionRole: !Not [ !Equals [ !Ref BastionRole, "" ] ]
+  WindowsRole: !Not [ !Equals [ !Ref WindowsNodeInstanceRoleArn, "" ] ]
   EnablePrivateEndpoint: !Equals [ !Ref EKSPrivateAccessEndpoint, "Enabled" ]
   EnablePublicEndpoint: !Equals [ !Ref EKSPublicAccessEndpoint, "Enabled" ]
   CreateKey: !And
@@ -131,6 +134,12 @@ Resources:
             - Arn: !Ref AdditionalEKSAdminRoleArn
               Username: !Ref AdditionalEKSAdminRoleArn
               Groups: [ 'system:masters' ]
+            - !Ref 'AWS::NoValue'
+          - !If 
+            - WindowsRole
+            - Arn: !Ref WindowsNodeInstanceRoleArn
+              Username: system:node:{{EC2PrivateDNSName}}
+              Groups: [ 'system:bootstrappers', 'system:nodes', 'eks:kube-proxy-windows']
             - !Ref 'AWS::NoValue'
         Users:
           - Arn: !GetAtt CallerArn.Arn

--- a/templates/amazon-eks-functions.template.yaml
+++ b/templates/amazon-eks-functions.template.yaml
@@ -471,3 +471,5 @@ Outputs:
     Value: !GetAtt NodeSGFunction.Arn
   FargateProfileLambdaArn:
     Value: !GetAtt FargateProfileLambda.Arn
+  KubeManifestLambdaArn:
+    Value: !GetAtt KubeManifestLambda.Arn

--- a/templates/amazon-eks-iam.template.yaml
+++ b/templates/amazon-eks-iam.template.yaml
@@ -34,12 +34,17 @@ Parameters:
     Type: String
     Default: "Enabled"
     AllowedValues: ["Enabled", "Disabled"]
+  CreateWindowsRole:
+    Type: String
+    Default: "Enabled"
+    AllowedValues: ["Enabled", "Disabled"]
   BastionIAMRoleName:
     Type: String
     Default: ""
 Conditions:
   CreateDeleteBucketContentsRole: !Equals [!Ref 'DeleteLambdaZipsBucketContents', "True"]
   EnableBastionRole: !Equals [!Ref CreateBastionRole, "Enabled"]
+  EnableWindowsRole: !Equals [!Ref CreateWindowsRole, "Enabled"]
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
 Resources:
   CreateVpcRoleRole:
@@ -213,6 +218,42 @@ Resources:
                 Resource: !Sub
                  - "arn:${AWS::Partition}:s3:::${BucketName}/${QSS3KeyPrefix}*"
                  - BucketName: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+  WindowsNodeInstanceRole:
+    Condition: EnableWindowsRole
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - !Sub "ec2.${AWS::URLSuffix}"
+            Action:
+              - "sts:AssumeRole"
+      Path: /      
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonElasticFileSystemReadOnlyAccess'
+      Policies:
+        - PolicyName: QSBucketAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub
+                 - "arn:${AWS::Partition}:s3:::${BucketName}/${QSS3KeyPrefix}*"
+                 - BucketName: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+  WindowsNodeInstanceProfile:
+    Condition: EnableWindowsRole
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: /
+      Roles:
+        - Ref: WindowsNodeInstanceRole
   BastionRole:
     Condition: EnableBastionRole
     Type: "AWS::IAM::Role"
@@ -514,6 +555,10 @@ Outputs:
     Value: !GetAtt NodeInstanceRole.Arn
   NodeInstanceRoleName:
     Value: !Ref NodeInstanceRole
+  WindowsNodeInstanceProfile:
+    Value: !If [EnableWindowsRole, !Ref WindowsNodeInstanceProfile, ""]
+  WindowsNodeInstanceRoleArn:
+    Value: !If [EnableWindowsRole, !GetAtt WindowsNodeInstanceRole.Arn, ""]
   BastionRole:
     Value: !If [EnableBastionRole, !Ref BastionRole, !Ref BastionIAMRoleName]
   CleanupLoadBalancersRoleArn:

--- a/templates/amazon-eks-master-existing-vpc.template.yaml
+++ b/templates/amazon-eks-master-existing-vpc.template.yaml
@@ -55,6 +55,15 @@ Metadata:
           - NewRelicIntegration
           - NewRelicLicenseKey
       - Label:
+          default: Optional Amazon EKS Windows configuration
+        Parameters:
+          - WindowsSupport
+          - WindowsNodeInstanceType
+          - WindowsNumberOfNodes
+          - WindowsMaxNumberOfNodes
+          - WindowsNodeGroupName
+          - WindowsNodeVolumeSize
+      - Label:
           default: AWS Quick Start configuration
         Parameters:
           - QSS3BucketName
@@ -95,6 +104,16 @@ Metadata:
         default: Managed node group AMI type
       MangedNodeGroupLabel:
         default: Managed node group label
+      WindowsSupport:
+        default: Allow for creation of Windows nodegroup
+      WindowsNodeInstanceType:
+        default: Windows node instance type
+      WindowsNumberOfNodes:
+        default: Number of Windows nodes
+      WindowsNodeGroupName:
+        default: Windows node group name
+      WindowsNodeVolumeSize:
+        default: Windows node volume size
       PublicSubnet1ID:
         default: Public subnet 1 ID
       PublicSubnet2ID:
@@ -220,80 +239,12 @@ Parameters:
     Type: String
   NodeInstanceType:
     Default: t3.medium
-    AllowedValues:
-      - t3.nano
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
-      - t3.2xlarge
-      - t3a.nano
-      - t3a.micro
-      - t3a.small
-      - t3a.medium
-      - t3a.large
-      - t3a.xlarge
-      - t3a.2xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m5.12xlarge
-      - m5.24xlarge
-      - m5a.large
-      - m5a.xlarge
-      - m5a.2xlarge
-      - m5a.4xlarge
-      - m5a.12xlarge
-      - m5a.24xlarge
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - c5.9xlarge
-      - c5.18xlarge
-      - c5a.large
-      - c5a.xlarge
-      - c5a.2xlarge
-      - c5a.4xlarge
-      - c5a.12xlarge
-      - c5a.24xlarge
-      - i3.large
-      - i3.xlarge
-      - i3.2xlarge
-      - i3.4xlarge
-      - i3.8xlarge
-      - i3.16xlarge
-      - x1.16xlarge
-      - x1.32xlarge
-      - p3.2xlarge
-      - p3.8xlarge
-      - p3.16xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
-      - r5.4xlarge
-      - r5.12xlarge
-      - r5.24xlarge
-      - r5a.large
-      - r5a.xlarge
-      - r5a.2xlarge
-      - r5a.4xlarge
-      - r5a.12xlarge
-      - r5a.24xlarge
-      - r5d.large
-      - r5d.xlarge
-      - r5d.2xlarge
-      - r5d.4xlarge
-      - r5d.12xlarge
-      - r5d.24xlarge
-      - z1d.large
-      - z1d.xlarge
-      - z1d.2xlarge
-      - z1d.3xlarge
-      - z1d.6xlarge
-      - z1d.12xlarge
+    AllowedValues: [t3.nano,t3.micro, t3.small, t3.medium, t3.large, t3.xlarge, t3.2xlarge, m5.large, m5.xlarge, m5.2xlarge
+                    m5.4xlarge, m5.12xlarge, m5.24xlarge, c5.large, c5.xlarge, c5.2xlarge, c5.4xlarge, c5.9xlarge, c5.18xlarge,
+                    i3.large, i3.xlarge, i3.2xlarge, i3.4xlarge, i3.8xlarge, i3.16xlarge, x1.16xlarge, x1.32xlarge, p3.2xlarge,
+                    p3.8xlarge, p3.16xlarge, r5.large, r5.xlarge, r5.2xlarge, r5.4xlarge, r5.12xlarge, r5.24xlarge, r5d.large, 
+                    r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.12xlarge, r5d.24xlarge, z1d.large, z1d.xlarge, z1d.2xlarge. 
+                    z1d.3xlarge, z1d.6xlarge, z1d.12xlarge]
     ConstraintDescription: Must be a valid EC2 instance type
     Description: The type of EC2 instance for the node instances.
     Type: String
@@ -393,6 +344,34 @@ Parameters:
     AllowedValues: [ "Enabled", "Disabled" ]
     Default: "Enabled"
     Description: "Skip creating a bastion host by setting this is set to Disabled."
+  WindowsSupport:
+    Type: String
+    AllowedValues: [ "Enabled", "Disabled" ]
+    Default: "Enabled"
+    Description: "Choose Enabled to create a Windows Nodegroup."
+  WindowsNodeInstanceType:
+    Default: t3.large
+    AllowedValues: [t3.nano,t3.micro, t3.small, t3.medium, t3.large, t3.xlarge, t3.2xlarge, m5.large, m5.xlarge, m5.2xlarge
+                    m5.4xlarge, m5.12xlarge, m5.24xlarge, c5.large, c5.xlarge, c5.2xlarge, c5.4xlarge, c5.9xlarge, c5.18xlarge,
+                    i3.large, i3.xlarge, i3.2xlarge, i3.4xlarge, i3.8xlarge, i3.16xlarge, x1.16xlarge, x1.32xlarge, p3.2xlarge,
+                    p3.8xlarge, p3.16xlarge, r5.large, r5.xlarge, r5.2xlarge, r5.4xlarge, r5.12xlarge, r5.24xlarge, r5d.large, 
+                    r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.12xlarge, r5d.24xlarge, z1d.large, z1d.xlarge, z1d.2xlarge. 
+                    z1d.3xlarge, z1d.6xlarge, z1d.12xlarge]
+    ConstraintDescription: Must be a valid EC2 instance type
+    Description: The type of EC2 instance for the node instances.
+    Type: String
+  WindowsNumberOfNodes:
+    Default: 3
+    Description: The number of Amazon EKS Windows node instances. The default is one for each of the three Availability Zones.
+    Type: Number
+  WindowsNodeGroupName:
+    Default: Default-Windows
+    Description: The name for EKS Windows node group.
+    Type: String
+  WindowsNodeVolumeSize:
+    Default: 50
+    Description: The size for the Windows node's root EBS volumes (should be at least 50 gb).
+    Type: String
   ALBIngressController:
     Type: String
     AllowedValues: [ "Enabled", "Disabled" ]
@@ -427,9 +406,8 @@ Parameters:
     AllowedValues: [Enabled, Disabled]
     Default: Disabled
     Description: "New Relic infrastructure monitoring integration. For more information see https://github.com/aws-quickstart/quickstart-eks-newrelic-infrastructure/ ."
-
 Rules:
-  EKSVersion_ManagedNodeGrou:
+  EKSVersion_ManagedNodeGroup:
     RuleCondition: !Equals [ !Ref 'ManagedNodeGroup', 'yes' ]
     Assertions:
       - AssertDescription: To use Managed Node Groups you must use EKS version 1.14 or higher
@@ -500,6 +478,11 @@ Resources:
         SnykIntegration: !Ref SnykIntegration
         NewRelicLicenseKey: !Ref NewRelicLicenseKey
         NewRelicIntegration: !Ref NewRelicIntegration
+        WindowsSupport: !Ref WindowsSupport
+        WindowsNodeInstanceType: !Ref WindowsNodeInstanceType
+        WindowsNumberOfNodes: !Ref WindowsNumberOfNodes
+        WindowsNodeGroupName: !Ref WindowsNodeGroupName
+        WindowsNodeVolumeSize: !Ref WindowsNodeVolumeSize
 Outputs:
   EKSClusterName:
     Value: !GetAtt EKSStack.Outputs.EKSClusterName

--- a/templates/amazon-eks-master.template.yaml
+++ b/templates/amazon-eks-master.template.yaml
@@ -75,6 +75,15 @@ Metadata:
           - NewRelicIntegration
           - NewRelicLicenseKey
       - Label:
+          default: Optional Amazon EKS Windows configuration
+        Parameters:
+          - WindowsSupport
+          - WindowsNodeInstanceType
+          - WindowsNumberOfNodes
+          - WindowsMaxNumberOfNodes
+          - WindowsNodeGroupName
+          - WindowsNodeVolumeSize
+      - Label:
           default: Optional Kubernetes add-ins
         Parameters:
           - ALBIngressController
@@ -134,6 +143,16 @@ Metadata:
         default: Managed node group AMI type
       MangedNodeGroupLabel:
         default: Managed node group label
+      WindowsSupport:
+        default: Allow for creation of Windows nodegroup
+      WindowsNodeInstanceType:
+        default: Windows node instance type
+      WindowsNumberOfNodes:
+        default: Number of Windows nodes
+      WindowsNodeGroupName:
+        default: Windows node group name
+      WindowsNodeVolumeSize:
+        default: Windows node volume size
       AdditionalEKSAdminUserArn:
         default: Additional EKS admin ARN (IAM user)
       AdditionalEKSAdminRoleArn:
@@ -318,80 +337,12 @@ Parameters:
     Type: String
   NodeInstanceType:
     Default: t3.medium
-    AllowedValues:
-      - t3.nano
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
-      - t3.2xlarge
-      - t3a.nano
-      - t3a.micro
-      - t3a.small
-      - t3a.medium
-      - t3a.large
-      - t3a.xlarge
-      - t3a.2xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m5.12xlarge
-      - m5.24xlarge
-      - m5a.large
-      - m5a.xlarge
-      - m5a.2xlarge
-      - m5a.4xlarge
-      - m5a.12xlarge
-      - m5a.24xlarge
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - c5.9xlarge
-      - c5.18xlarge
-      - c5a.large
-      - c5a.xlarge
-      - c5a.2xlarge
-      - c5a.4xlarge
-      - c5a.12xlarge
-      - c5a.24xlarge
-      - i3.large
-      - i3.xlarge
-      - i3.2xlarge
-      - i3.4xlarge
-      - i3.8xlarge
-      - i3.16xlarge
-      - x1.16xlarge
-      - x1.32xlarge
-      - p3.2xlarge
-      - p3.8xlarge
-      - p3.16xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
-      - r5.4xlarge
-      - r5.12xlarge
-      - r5.24xlarge
-      - r5a.large
-      - r5a.xlarge
-      - r5a.2xlarge
-      - r5a.4xlarge
-      - r5a.12xlarge
-      - r5a.24xlarge
-      - r5d.large
-      - r5d.xlarge
-      - r5d.2xlarge
-      - r5d.4xlarge
-      - r5d.12xlarge
-      - r5d.24xlarge
-      - z1d.large
-      - z1d.xlarge
-      - z1d.2xlarge
-      - z1d.3xlarge
-      - z1d.6xlarge
-      - z1d.12xlarge
+    AllowedValues: [t3.nano,t3.micro, t3.small, t3.medium, t3.large, t3.xlarge, t3.2xlarge, m5.large, m5.xlarge, m5.2xlarge
+                    m5.4xlarge, m5.12xlarge, m5.24xlarge, c5.large, c5.xlarge, c5.2xlarge, c5.4xlarge, c5.9xlarge, c5.18xlarge,
+                    i3.large, i3.xlarge, i3.2xlarge, i3.4xlarge, i3.8xlarge, i3.16xlarge, x1.16xlarge, x1.32xlarge, p3.2xlarge,
+                    p3.8xlarge, p3.16xlarge, r5.large, r5.xlarge, r5.2xlarge, r5.4xlarge, r5.12xlarge, r5.24xlarge, r5d.large, 
+                    r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.12xlarge, r5d.24xlarge, z1d.large, z1d.xlarge, z1d.2xlarge. 
+                    z1d.3xlarge, z1d.6xlarge, z1d.12xlarge]
     ConstraintDescription: Must be a valid EC2 instance type
     Description: The type of EC2 instance for the node instances.
     Type: String
@@ -401,7 +352,7 @@ Parameters:
     Type: Number
   MaxNumberOfNodes:
     Default: 3
-    Description: The maximum number of Amazon EKS node instances. The default is three node.
+    Description: The maximum number of Amazon EKS node instances. The default is three nodes.
     Type: Number  
   NodeGroupName:
     Default: Default
@@ -475,6 +426,34 @@ Parameters:
     AllowedValues: [ "Enabled", "Disabled" ]
     Default: "Enabled"
     Description: "Skip creating a bastion host by setting this is set to Disabled."
+  WindowsSupport:
+    Type: String
+    AllowedValues: [ "Enabled", "Disabled" ]
+    Default: "Enabled"
+    Description: "Choose Enabled to create a Windows Nodegroup."
+  WindowsNodeInstanceType:
+    Default: t3.large
+    AllowedValues: [t3.nano,t3.micro, t3.small, t3.medium, t3.large, t3.xlarge, t3.2xlarge, m5.large, m5.xlarge, m5.2xlarge
+                    m5.4xlarge, m5.12xlarge, m5.24xlarge, c5.large, c5.xlarge, c5.2xlarge, c5.4xlarge, c5.9xlarge, c5.18xlarge,
+                    i3.large, i3.xlarge, i3.2xlarge, i3.4xlarge, i3.8xlarge, i3.16xlarge, x1.16xlarge, x1.32xlarge, p3.2xlarge,
+                    p3.8xlarge, p3.16xlarge, r5.large, r5.xlarge, r5.2xlarge, r5.4xlarge, r5.12xlarge, r5.24xlarge, r5d.large, 
+                    r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.12xlarge, r5d.24xlarge, z1d.large, z1d.xlarge, z1d.2xlarge. 
+                    z1d.3xlarge, z1d.6xlarge, z1d.12xlarge]
+    ConstraintDescription: Must be a valid EC2 instance type
+    Description: The type of EC2 instance for the node instances.
+    Type: String
+  WindowsNumberOfNodes:
+    Default: 3
+    Description: The number of Amazon EKS Windows node instances. The default is one for each of the three Availability Zones.
+    Type: Number
+  WindowsNodeGroupName:
+    Default: Default-Windows
+    Description: The name for EKS Windows node group.
+    Type: String
+  WindowsNodeVolumeSize:
+    Default: 50
+    Description: The size for the Windows node's root EBS volumes (should be at least 50 gb).
+    Type: String
   ALBIngressController:
     Type: String
     AllowedValues: [ "Enabled", "Disabled" ]
@@ -535,6 +514,20 @@ Rules:
         Assert: !Contains
           - [ '1.16', '1.15', '1.14' ]
           - !Ref 'KubernetesVersion'
+  EKSVersion_WindowsNodeGroup:
+    RuleCondition: !Equals [ !Ref 'WindowsSupport', 'Enabled' ]
+    Assertions:
+      - AssertDescription: To use Windows Node Groups you must use EKS version 1.14 or higher
+        Assert: !Contains
+          - [ '1.16', '1.15', '1.14' ]
+          - !Ref 'KubernetesVersion'
+  ClusterAutoScalerVerification:
+    RuleCondition: !Equals [ !Ref 'ManagedNodeGroup', 'yes' ]
+    Assertions:
+      - AssertDescription: To use Cluster AutoScaler you should not use Managed Node Groups
+        Assert: !Contains
+          - - 'Disabled'
+          - !Ref 'ClusterAutoScaler'
 Conditions:
   3AZDeployment: !Equals [!Ref NumberOfAZs, "3"]
   2AZDeployment: !Or
@@ -632,6 +625,11 @@ Resources:
         SnykIntegration: !Ref SnykIntegration
         NewRelicLicenseKey: !Ref NewRelicLicenseKey
         NewRelicIntegration: !Ref NewRelicIntegration
+        WindowsSupport: !Ref WindowsSupport
+        WindowsNodeInstanceType: !Ref WindowsNodeInstanceType
+        WindowsNumberOfNodes: !Ref WindowsNumberOfNodes
+        WindowsNodeGroupName: !Ref WindowsNodeGroupName
+        WindowsNodeVolumeSize: !Ref WindowsNodeVolumeSize
 Outputs:
   EKSClusterName:
     Value: !GetAtt EKSStack.Outputs.EKSClusterName

--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -196,80 +196,12 @@ Parameters:
     Default: ""
   NodeInstanceType:
     Default: t3.medium
-    AllowedValues:
-      - t3.nano
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
-      - t3.2xlarge
-      - t3a.nano
-      - t3a.micro
-      - t3a.small
-      - t3a.medium
-      - t3a.large
-      - t3a.xlarge
-      - t3a.2xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m5.12xlarge
-      - m5.24xlarge
-      - m5a.large
-      - m5a.xlarge
-      - m5a.2xlarge
-      - m5a.4xlarge
-      - m5a.12xlarge
-      - m5a.24xlarge
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - c5.9xlarge
-      - c5.18xlarge
-      - c5a.large
-      - c5a.xlarge
-      - c5a.2xlarge
-      - c5a.4xlarge
-      - c5a.12xlarge
-      - c5a.24xlarge
-      - i3.large
-      - i3.xlarge
-      - i3.2xlarge
-      - i3.4xlarge
-      - i3.8xlarge
-      - i3.16xlarge
-      - x1.16xlarge
-      - x1.32xlarge
-      - p3.2xlarge
-      - p3.8xlarge
-      - p3.16xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
-      - r5.4xlarge
-      - r5.12xlarge
-      - r5.24xlarge
-      - r5a.large
-      - r5a.xlarge
-      - r5a.2xlarge
-      - r5a.4xlarge
-      - r5a.12xlarge
-      - r5a.24xlarge
-      - r5d.large
-      - r5d.xlarge
-      - r5d.2xlarge
-      - r5d.4xlarge
-      - r5d.12xlarge
-      - r5d.24xlarge
-      - z1d.large
-      - z1d.xlarge
-      - z1d.2xlarge
-      - z1d.3xlarge
-      - z1d.6xlarge
-      - z1d.12xlarge
+    AllowedValues: [t3.nano,t3.micro, t3.small, t3.medium, t3.large, t3.xlarge, t3.2xlarge, m5.large, m5.xlarge, m5.2xlarge
+                    m5.4xlarge, m5.12xlarge, m5.24xlarge, c5.large, c5.xlarge, c5.2xlarge, c5.4xlarge, c5.9xlarge, c5.18xlarge,
+                    i3.large, i3.xlarge, i3.2xlarge, i3.4xlarge, i3.8xlarge, i3.16xlarge, x1.16xlarge, x1.32xlarge, p3.2xlarge,
+                    p3.8xlarge, p3.16xlarge, r5.large, r5.xlarge, r5.2xlarge, r5.4xlarge, r5.12xlarge, r5.24xlarge, r5d.large, 
+                    r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.12xlarge, r5d.24xlarge, z1d.large, z1d.xlarge, z1d.2xlarge. 
+                    z1d.3xlarge, z1d.6xlarge, z1d.12xlarge]
     ConstraintDescription: Must be a valid EC2 instance type
     Description: Type of EC2 instance for the node instances
     Type: String

--- a/templates/amazon-eks-windows-nodegroup.template.yaml
+++ b/templates/amazon-eks-windows-nodegroup.template.yaml
@@ -1,0 +1,266 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Amazon EKS - Windows Node Group.
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Network configuration
+        Parameters:
+          - VPCID
+          - PrivateSubnet1ID
+          - PrivateSubnet2ID
+          - PrivateSubnet3ID
+          - NodeSecurityGroup
+      - Label:
+          default: Amazon EC2 configuration
+        Parameters:
+          - KeyPairName
+          - NodeAmiIdSSMParam
+          - CustomAmiId
+          - NodeInstanceType
+          - NodeVolumeSize
+          - BootstrapArguments
+      - Label:
+          default: EKS configuration
+        Parameters:
+          - ClusterName
+          - NumberOfNodes
+          - MaxNumberOfNodes
+          - NodeGroupName
+          - NodeInstanceProfile
+          - NodeInstanceRoleArn
+          - ControlPlaneSecurityGroup
+      - Label:
+          default: AWS Quick Start configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
+          - QSS3BucketRegion
+    ParameterLabels:
+      VPCID:
+        default: VPC ID
+      PrivateSubnet1ID:
+        default: Private Subnet 1 ID
+      PrivateSubnet2ID:
+        default: Private Subnet 2 ID
+      PrivateSubnet3ID:
+        default: Private Subnet 3 ID
+      NodeSecurityGroup:
+        default: Linux node security group
+      KeyPairName:
+        default: SSH key name
+      NodeAmiIdSSMParam:
+        default: SSM parameter for Windows AMI ID
+      CustomAmiId:
+        default: Custom AMI ID
+      NodeInstanceType:
+        default: Node instance type
+      NodeVolumeSize:
+        default: Node volume size
+      BootstrapArguments:
+        default: Arguments to bootstrap script
+      ClusterName:
+        default: EKS cluster name
+      NumberOfNodes:
+        default: Number of nodes
+      MaxNumberOfNodes:
+        default: Maximum number of nodes
+      NodeGroupName:
+        default: Name of node group
+      NodeInstanceProfile:
+        default: Node instance profile
+      NodeInstanceRoleArn:
+        default: Node instance role ARN
+      ControlPlaneSecurityGroup:
+        default: Control plane security group
+      QSS3BucketName:
+        default: Quick Start S3 bucket name
+      QSS3KeyPrefix:
+        default: Quick Start S3 key prefix
+      QSS3BucketRegion:
+        default: Quick Start S3 bucket region
+Parameters:
+  VPCID:
+    Description: ID of your existing VPC for deployment
+    Type: AWS::EC2::VPC::Id
+  PrivateSubnet1ID:
+    Description: ID of private subnet 1 in Availability Zone 1 for the workload (e.g.,
+      subnet-a0246123)
+    Type: AWS::EC2::Subnet::Id
+  PrivateSubnet2ID:
+    Description: ID of private subnet 2 in Availability Zone 2 for the workload (e.g.,
+      subnet-b1f432cd)
+    Type: String
+    Default: ""
+  PrivateSubnet3ID:
+    Description: ID of private subnet 3 in Availability Zone 3 for the workload (e.g.,
+      subnet-b1f4a2cd)
+    Type: String
+    Default: ""
+  NodeSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup::Id"
+    Description: The security group created for existing worker node groups.
+  KeyPairName:
+    Type: "AWS::EC2::KeyPair::KeyName"
+    Description: Name of an existing EC2 key pair. All instances will launch with
+      this key pair.
+  NodeAmiIdSSMParam:
+    Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
+    Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Core-EKS_Optimized-1.14/image_id 
+    Description: AWS Systems Manager Parameter Store parameter of the default AMI ID for the Windows worker node instances.
+  CustomAmiId:
+    Type: String
+    Default: ""
+    Description: (Optional) Specify your own custom AMI ID. This value overrides the AWS Systems Manager Parameter Store value specified above.
+  NodeInstanceType:
+    Type: String
+    Default: m5.large
+    AllowedValues: [t3.nano,t3.micro, t3.small, t3.medium, t3.large, t3.xlarge, t3.2xlarge, m5.large, m5.xlarge, m5.2xlarge
+                    m5.4xlarge, m5.12xlarge, m5.24xlarge, c5.large, c5.xlarge, c5.2xlarge, c5.4xlarge, c5.9xlarge, c5.18xlarge,
+                    i3.large, i3.xlarge, i3.2xlarge, i3.4xlarge, i3.8xlarge, i3.16xlarge, x1.16xlarge, x1.32xlarge, p3.2xlarge,
+                    p3.8xlarge, p3.16xlarge, r5.large, r5.xlarge, r5.2xlarge, r5.4xlarge, r5.12xlarge, r5.24xlarge, r5d.large, 
+                    r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.12xlarge, r5d.24xlarge, z1d.large, z1d.xlarge, z1d.2xlarge. 
+                    z1d.3xlarge, z1d.6xlarge, z1d.12xlarge]
+    ConstraintDescription: Must be a valid EC2 instance type
+    Description: EC2 instance type for the node instances
+  NodeVolumeSize:
+    Type: Number
+    Default: 50
+    Description: Node volume size (should be at least 50 gb)
+  BootstrapArguments:
+    Type: String
+    Default: ""
+    Description: "Arguments to pass to the bootstrap script."
+  ClusterName:
+    Type: String
+    Description: The cluster name provided when the cluster was created. If it is incorrect, nodes will not be able to join the cluster.
+  NumberOfNodes:
+    Default: 3
+    Description: Number of EKS node instances
+    Type: Number
+  MaxNumberOfNodes:
+    Default: ""
+    Description: "[OPTIONAL] The maximum number of Amazon EKS node instances, if left blank will be set to the same value as NumberOfNodes"
+    Type: String
+  NodeGroupName:
+    Default: Default-Windows
+    Description: Name for EKS node group
+    Type: String
+  NodeInstanceProfile:
+    Type: String
+    Description: ARN for IAM Instance Profile to attach to nodes
+  NodeInstanceRoleArn:
+    Type: String
+    Description: IAM Role ARN to attach to nodes
+  ControlPlaneSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup::Id"
+    Description: The security group of the EKS cluster control plane.
+  QSS3BucketName:
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
+      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
+      (-).
+    Default: aws-quickstart
+    Description: S3 bucket name for the Quick Start assets. This string can include
+      numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start
+      or end with a hyphen (-).
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: ^[0-9a-zA-Z-/.]*$
+    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
+      uppercase letters, hyphens (-), dots(.) and forward slash (/).
+    Default: quickstart-amazon-eks/
+    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), dots(.) and
+      forward slash (/).
+    Type: String
+  QSS3BucketRegion:
+    Default: 'us-east-1'
+    Description: The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is
+      hosted. When using your own bucket, you must specify this value.
+    Type: String
+
+Conditions:
+  3AZDeployment: !Not [!Equals [!Ref PrivateSubnet3ID, ""]]
+  2AZDeployment: !Or
+    - !Not [!Equals [!Ref PrivateSubnet2ID, ""]]
+    - !Not [!Equals [!Ref PrivateSubnet3ID, ""]]
+  UseCustomAmi: !Not [ !Equals [ !Ref CustomAmiId, "" ] ]
+  MaxNodes: !Not [ !Equals [ !Ref MaxNumberOfNodes, "" ] ]
+Resources:
+  NodeLaunchConfig:
+    Type: "AWS::AutoScaling::LaunchConfiguration"
+    Properties:
+      AssociatePublicIpAddress: false
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: !Ref NodeVolumeSize
+            VolumeType: gp2
+      IamInstanceProfile: !Ref NodeInstanceProfile
+      ImageId: !If
+        - UseCustomAmi
+        - Ref: CustomAmiId
+        - Ref: NodeAmiIdSSMParam
+      InstanceType: !Ref NodeInstanceType
+      KeyName: !Ref KeyPairName
+      SecurityGroups: 
+        - !Ref NodeSecurityGroup
+      UserData: !Base64
+        "Fn::Sub": |
+            <powershell>
+            [string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
+            [string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'
+            [string]$EKSBootstrapScriptFile = "$EKSBinDir\$EKSBootstrapScriptName"
+            [string]$cfn_signal = "$env:ProgramFiles\Amazon\cfn-bootstrap\cfn-signal.exe"
+            & $EKSBootstrapScriptFile -EKSClusterName ${ClusterName} ${BootstrapArguments} 3>&1 4>&1 5>&1 6>&1
+            $LastError = if ($?) { 0 } else { $Error[0].Exception.HResult }
+            & $cfn_signal --exit-code=$LastError `
+              --stack="${AWS::StackName}" `
+              --resource="NodeGroup" `
+              --region=${AWS::Region}
+            </powershell>
+
+  NodeGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      DesiredCapacity: !Ref NumberOfNodes
+      LaunchConfigurationName: !Ref NodeLaunchConfig
+      MinSize: !Ref NumberOfNodes
+      MaxSize: !If [ MaxNodes, !Ref MaxNumberOfNodes, !Ref NumberOfNodes ]
+      VPCZoneIdentifier: !If
+        - 3AZDeployment
+        - [ !Ref PrivateSubnet1ID, !Ref PrivateSubnet2ID, !Ref PrivateSubnet3ID ]
+        - !If
+          - 2AZDeployment
+          - [ !Ref PrivateSubnet1ID, !Ref PrivateSubnet2ID ]
+          - [ !Ref PrivateSubnet1ID ]
+      Tags:
+        - Key: Name
+          PropagateAtLaunch: "true"
+          Value: !Sub ${ClusterName}-${NodeGroupName}-Node
+        - Key: !Sub kubernetes.io/cluster/${ClusterName}
+          PropagateAtLaunch: "true"
+          Value: owned
+        - Key: k8s.io/cluster-autoscaler/enabled
+          Value: 'true'
+          PropagateAtLaunch: true
+        - Key: !Sub 'k8s.io/cluster-autoscaler/${ClusterName}'
+          Value: ''
+          PropagateAtLaunch: true
+    CreationPolicy:
+      ResourceSignal:
+        Count: !Ref NumberOfNodes
+        Timeout: PT15M
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: !Ref NumberOfNodes
+        MaxBatchSize: 1
+        WaitOnResourceSignals : true
+        PauseTime: PT15M
+
+Outputs:
+  NodeInstanceRoleArn:
+    Description: The node instance role ARN
+    Value: !Ref  NodeInstanceRoleArn

--- a/templates/amazon-eks-windows-support-workload.template.yaml
+++ b/templates/amazon-eks-windows-support-workload.template.yaml
@@ -1,0 +1,137 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "deploy a workload to the cluster to prepare the cluster for running Windows workloads"
+Parameters:
+  ClusterName:
+    Type: String
+  ClusterKubeServerEndpoint:
+    Type: String
+  ClusterCACert:
+    Type: String
+  OIDCProvider:
+    Type: String
+  QSS3BucketName:
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: ^[0-9a-zA-Z-/.]*$
+    Type: String
+  QSS3BucketRegion:
+    Type: String
+Resources:
+  # This resource creates a Service Account that has no permissions associated with it.
+  # It will be used to authorize our pod to run 'kubectl' commands
+  ServiceAccount:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:EKS-QuickStart-KubeManifest-${ClusterName}"
+      ClusterName: !Ref ClusterName
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: internal-kubectl
+          namespace: default
+          annotations:
+            eks.amazonaws.com/role-arn: !GetAtt S3Role.Arn
+  # Creates role binding to give our service account admin access
+  ServiceClusterRoleBinding:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:EKS-QuickStart-KubeManifest-${ClusterName}"
+      ClusterName: !Ref ClusterName
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: internal-kubectl-admin
+          namespace: default
+        subjects:
+          - kind: ServiceAccount
+            name: internal-kubectl
+            namespace: default
+        roleRef:
+          kind: ClusterRole
+          name: cluster-admin
+          apiGroup: rbac.authorization.k8s.io
+  # Role used by the service account to pull from S3 Bucket
+  S3Role:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDCProvider}"
+              },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                "StringEquals": {
+                  "${OIDCProvider}:sub": "system:serviceaccount:${NameSpace}:${ResourceName}"
+                }
+              }
+            }
+          ]
+        }
+      - NameSpace: default
+        ResourceName: internal-kubectl
+      Path: "/"
+      Policies:
+      - PolicyName: QSBucketAccess
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: s3:GetObject
+              Resource: !Sub "arn:${AWS::Partition}:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*"
+  # This Job is used to setup the Windows VPC Webhook and Resource Controller
+  JobResource:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:EKS-QuickStart-KubeManifest-${ClusterName}"
+      ClusterName: !Ref ClusterName
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: windows-prep
+        spec:
+          template:
+            spec:
+              serviceAccountName: internal-kubectl
+              containers:
+              - name: windows-prep-container
+                image: amazonlinux:2
+                command: ["/bin/bash","-c"]
+                args: 
+                  - !Sub >
+                    sleep 10;
+                    yum install -y awscli;
+                    export AWS_REGION=${AWS::Region};
+                    echo ${!S3_SCRIPT_URL};
+                    aws s3 cp ${!S3_SCRIPT_URL} ./windows-setup.sh;
+                    chmod +x ./windows-setup.sh;
+                    ./windows-setup.sh
+                env:
+                  - name: K8S_ENDPOINT
+                    value: !Ref ClusterKubeServerEndpoint
+                  - name: K8S_CA_DATA
+                    value: !Ref ClusterCACert
+                  - name: K8S_CLUSTER_NAME
+                    value: !Ref ClusterName
+                  - name: S3_SCRIPT_URL
+                    value: !Sub 's3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/windows-setup.sh'
+              restartPolicy: OnFailure
+          backoffLimit: 4

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -57,80 +57,12 @@ Parameters:
     Default: ""
   NodeInstanceType:
     Default: t3.medium
-    AllowedValues:
-      - t3.nano
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
-      - t3.2xlarge
-      - t3a.nano
-      - t3a.micro
-      - t3a.small
-      - t3a.medium
-      - t3a.large
-      - t3a.xlarge
-      - t3a.2xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m5.12xlarge
-      - m5.24xlarge
-      - m5a.large
-      - m5a.xlarge
-      - m5a.2xlarge
-      - m5a.4xlarge
-      - m5a.12xlarge
-      - m5a.24xlarge
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - c5.9xlarge
-      - c5.18xlarge
-      - c5a.large
-      - c5a.xlarge
-      - c5a.2xlarge
-      - c5a.4xlarge
-      - c5a.12xlarge
-      - c5a.24xlarge
-      - i3.large
-      - i3.xlarge
-      - i3.2xlarge
-      - i3.4xlarge
-      - i3.8xlarge
-      - i3.16xlarge
-      - x1.16xlarge
-      - x1.32xlarge
-      - p3.2xlarge
-      - p3.8xlarge
-      - p3.16xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
-      - r5.4xlarge
-      - r5.12xlarge
-      - r5.24xlarge
-      - r5a.large
-      - r5a.xlarge
-      - r5a.2xlarge
-      - r5a.4xlarge
-      - r5a.12xlarge
-      - r5a.24xlarge
-      - r5d.large
-      - r5d.xlarge
-      - r5d.2xlarge
-      - r5d.4xlarge
-      - r5d.12xlarge
-      - r5d.24xlarge
-      - z1d.large
-      - z1d.xlarge
-      - z1d.2xlarge
-      - z1d.3xlarge
-      - z1d.6xlarge
-      - z1d.12xlarge
+    AllowedValues: [t3.nano,t3.micro, t3.small, t3.medium, t3.large, t3.xlarge, t3.2xlarge, m5.large, m5.xlarge, m5.2xlarge
+                    m5.4xlarge, m5.12xlarge, m5.24xlarge, c5.large, c5.xlarge, c5.2xlarge, c5.4xlarge, c5.9xlarge, c5.18xlarge,
+                    i3.large, i3.xlarge, i3.2xlarge, i3.4xlarge, i3.8xlarge, i3.16xlarge, x1.16xlarge, x1.32xlarge, p3.2xlarge,
+                    p3.8xlarge, p3.16xlarge, r5.large, r5.xlarge, r5.2xlarge, r5.4xlarge, r5.12xlarge, r5.24xlarge, r5d.large, 
+                    r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.12xlarge, r5d.24xlarge, z1d.large, z1d.xlarge, z1d.2xlarge. 
+                    z1d.3xlarge, z1d.6xlarge, z1d.12xlarge]
     ConstraintDescription: Must be a valid EC2 instance type
     Type: String
   NumberOfNodes:
@@ -162,6 +94,34 @@ Parameters:
     Description: Add a custom name label to the Managed Node Group Nodes. If you dont do this then a default one will be added for you.
     Type: String
     Default: ''
+  WindowsSupport:
+    AllowedValues: ["Enabled", "Disabled"]
+    Description: Choose Enabled to create a Windows Nodegroup. If you choose "Enabled", you must select Kubernetes Version 1.14 or higher.
+    Type: String
+    Default: "Disabled"
+  WindowsCustomAmiId:
+    Description: (Optional) Specify your own custom AMI ID.
+    Type: String
+    Default: ""
+  WindowsNodeInstanceType:
+    Default: t3.medium
+    AllowedValues: [t3.nano,t3.micro, t3.small, t3.medium, t3.large, t3.xlarge, t3.2xlarge, m5.large, m5.xlarge, m5.2xlarge
+                    m5.4xlarge, m5.12xlarge, m5.24xlarge, c5.large, c5.xlarge, c5.2xlarge, c5.4xlarge, c5.9xlarge, c5.18xlarge,
+                    i3.large, i3.xlarge, i3.2xlarge, i3.4xlarge, i3.8xlarge, i3.16xlarge, x1.16xlarge, x1.32xlarge, p3.2xlarge,
+                    p3.8xlarge, p3.16xlarge, r5.large, r5.xlarge, r5.2xlarge, r5.4xlarge, r5.12xlarge, r5.24xlarge, r5d.large, 
+                    r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.12xlarge, r5d.24xlarge, z1d.large, z1d.xlarge, z1d.2xlarge. 
+                    z1d.3xlarge, z1d.6xlarge, z1d.12xlarge]
+    ConstraintDescription: Must be a valid EC2 instance type
+    Type: String
+  WindowsNumberOfNodes:
+    Default: 3
+    Type: Number
+  WindowsNodeGroupName:
+    Default: Default-Windows
+    Type: String
+  WindowsNodeVolumeSize:
+    Default: 50
+    Type: String
   LambdaZipsBucketName:
     Type: String
     Default: ''
@@ -306,8 +266,13 @@ Conditions:
   EnableALBIngressController: !Equals [!Ref 'ProvisionALBIngressController', 'Enabled']
   EnableMonitoringPrometheusGrafana: !Equals [!Ref 'ProvisionMonitoringStack', 'Prometheus + Grafana']
   EnableEfs: !Equals [!Ref 'EfsStorageClass', 'Enabled']
+  EnableWindows: !Equals [!Ref 'WindowsSupport', 'Enabled']
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   GenerateClusterName: !Equals [!Ref 'EKSClusterName', '']
+  EnableOIDC: !Or
+    - !Equals [!Ref 'ProvisionALBIngressController', 'Enabled']
+    - !Equals [!Ref 'WindowsSupport', 'Enabled']
+    - !Equals [!Ref IamOidcProvider, "Enabled"]
 Resources:
   BastionEksPermissions:
     Condition: EnableBastion
@@ -409,6 +374,34 @@ Resources:
         QSS3BucketRegion: !Ref QSS3BucketRegion
         CleanupSecurityGroupDependenciesLambdaArn: !GetAtt FunctionStack.Outputs.CleanupSecurityGroupDependenciesLambdaArn
         NodeSGFunctionArn: !GetAtt FunctionStack.Outputs.NodeSGFunctionArn
+  WindowsNodeGroupStack:
+    Condition: EnableWindows
+    DependsOn: WindowsSupportStack
+    Type: "AWS::CloudFormation::Stack"
+    Properties:
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/amazon-eks-windows-nodegroup.template.yaml'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      Parameters:
+        KeyPairName: !Ref 'KeyPairName'
+        PrivateSubnet1ID: !Ref PrivateSubnet1ID
+        PrivateSubnet2ID: !If [2AZDeployment, !Ref PrivateSubnet2ID, !Ref "AWS::NoValue" ]
+        PrivateSubnet3ID: !If [3AZDeployment, !Ref PrivateSubnet3ID, !Ref "AWS::NoValue" ]
+        VPCID: !Ref VPCID
+        CustomAmiId: !Ref WindowsCustomAmiId
+        NodeInstanceType: !Ref WindowsNodeInstanceType
+        NumberOfNodes: !Ref WindowsNumberOfNodes
+        NodeGroupName: !Ref WindowsNodeGroupName
+        NodeVolumeSize: !Ref WindowsNodeVolumeSize
+        NodeSecurityGroup: !GetAtt NodeGroupStack.Outputs.EKSNodeSecurityGroup
+        ClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
+        ControlPlaneSecurityGroup: !Ref ControlPlaneSecurityGroup
+        NodeInstanceProfile: !GetAtt IamStack.Outputs.WindowsNodeInstanceProfile
+        NodeInstanceRoleArn: !GetAtt IamStack.Outputs.WindowsNodeInstanceRoleArn
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        QSS3BucketRegion: !Ref QSS3BucketRegion
   BastionSShToNodes:
     Condition: EnableBastion
     Type: "AWS::EC2::SecurityGroupIngress"
@@ -442,6 +435,7 @@ Resources:
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         CreateBastionRole: !If [CustomBastionRole, "Disabled", !If [EnableBastion, "Enabled", "Disabled"]]
+        CreateWindowsRole: !Ref WindowsSupport
         BastionIAMRoleName: !Ref BastionIAMRoleName
   FunctionStack:
     Type: "AWS::CloudFormation::Stack"
@@ -574,6 +568,7 @@ Resources:
               - !Join [",", [ !Ref PrivateSubnet1ID ]]
         RoleArn: !GetAtt IamStack.Outputs.ControlPlaneRoleArn
         NodeInstanceRoleArn: !GetAtt IamStack.Outputs.NodeInstanceRoleArn
+        WindowsNodeInstanceRoleArn: !GetAtt IamStack.Outputs.WindowsNodeInstanceRoleArn
         AdditionalEKSAdminUserArn: !Ref AdditionalEKSAdminUserArn
         AdditionalEKSAdminRoleArn: !Ref AdditionalEKSAdminRoleArn
         KubernetesVersion: !Ref KubernetesVersion
@@ -587,7 +582,7 @@ Resources:
         EKSClusterLoggingTypes: !Join [ ',', !Ref 'EKSClusterLoggingTypes' ]
         EKSEncryptSecrets: !Ref EKSEncryptSecrets
         EKSEncryptSecretsKmsKeyArn: !Ref EKSEncryptSecretsKmsKeyArn
-        IamOidcProvider: !If [ EnableALBIngressController, 'Enabled', !Ref IamOidcProvider ]
+        IamOidcProvider: !If [EnableOIDC, 'Enabled', 'Disabled']
         EKSClusterName: !If [GenerateClusterName, !Ref GenerateName, !Ref EKSClusterName]
   PrometheusStack:
     Metadata:
@@ -724,6 +719,23 @@ Resources:
         KubeClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
         SnykIntegrationId: !Ref SnykIntegrationId
         Namespace: snyk-monitor
+  WindowsSupportStack:
+    DependsOn: NodeGroupStack
+    Condition: EnableWindows
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/amazon-eks-windows-support-workload.template.yaml'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      Parameters:
+        ClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
+        ClusterKubeServerEndpoint: !GetAtt EKSControlPlane.Outputs.EKSEndpoint
+        ClusterCACert: !GetAtt EKSControlPlane.Outputs.CAData
+        OIDCProvider: !Join [ '', !Split [ 'https://', !GetAtt EKSControlPlane.Outputs.OIDCIssuerURL ] ]
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        QSS3BucketRegion: !Ref QSS3BucketRegion
 Outputs:
   BastionIP:
     Value: !If


### PR DESCRIPTION
A CFN solution to supporting Windows Containers on EKS

I accomplish this by launching an EKS Cluster with Linux nodes, using the Quickstart lambda to run a Job on the Cluster that sets up the VPC controller and admission webhook. The details for how to do this are laid out here: https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html
The documentation for how these work does not exist unfortunately:
https://github.com/aws/containers-roadmap/issues/889
After this windows-support workload is run, we then deploy a windows nodegroup.

- You can view my annotations for specific portions that may be confusing.
- This _should_ work with Kubernetes 1.16 as I believe they updated their manifests in response to my query:
https://github.com/awsdocs/amazon-eks-user-guide/issues/157
- There are 65 params in the eks.yaml at the moment, to run windows support I usually comment out the snyk and newrelic stuff. I believe there is a solution for this pending involving ssm.
- Big thank you to Jay McConnell for answering my many QS and K8s questions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
