### PR TITLE
fix for "Error validating schemaHandlerPackage"

### DIFF
--- a/templates/amazon-eks-iam.template.yaml
+++ b/templates/amazon-eks-iam.template.yaml
@@ -395,6 +395,14 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                  - "s3:GetObject"
+                Resource: !Sub 'arn:${AWS::Partition}:s3:::${LambdaZipsBucketName}/functions/packages/*'
+        - PolicyName: ResourceTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
                   - "cloudformation:*"
                   - "iam:PassRole"
                   - "iam:CreateRole"
@@ -406,6 +414,7 @@ Resources:
                   - "ssm:GetParameter"
                   - "ssm:PutParameter"
                   - "sts:GetCallerIdentity"
+                  - "s3:GetObject"
                 Resource: "*"
   RegisterCustomResourceRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Unsure of the root cause, but newly created AWS accounts seem to need this additional permission in order to register CFN resource types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
