### PR TITLE
Bubble up properties needed to create add'l node groups

### DIFF
--- a/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
+++ b/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -451,3 +451,11 @@ Outputs:
     Value: !GetAtt EKSStack.Outputs.BastionSecurityGroup
   NodeGroupSecurityGroup:
     Value: !GetAtt EKSStack.Outputs.NodeGroupSecurityGroup
+  NodeInstanceProfile:
+    Value: !GetAtt EKSStack.Outputs.NodeInstanceProfile
+  NodeInstanceRoleName:
+    Value: !GetAtt EKSStack.Outputs.NodeInstanceRoleName
+  NodeInstanceRoleArn:
+    Value: !GetAtt EKSStack.Outputs.NodeInstanceRoleArn
+  ControlPlaneSecurityGroup:
+    Value: !GetAtt EKSStack.Outputs.ControlPlaneSecurityGroup


### PR DESCRIPTION
*Description of changes:*
Bubble up properties from `amazon-eks` to `amazon-eks-entrypoint-existing-vpc` so that framework users who depend on the existing vpc entrypoint can create additional node groups using its outputs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
