### PR TITLE
authorize clean lb lambda to delete eni

### DIFF
--- a/templates/amazon-eks-iam.template.yaml
+++ b/templates/amazon-eks-iam.template.yaml
@@ -284,6 +284,8 @@ Resources:
                   - 'ec2:DescribeTags'
                   - 'ec2:DeleteSecurityGroup'
                   - 'ec2:DescribeNetworkInterfaces'
+                  - 'ec2:DeleteNetworkInterface'
+                  - 'ec2:DetachNetworkInterface'
                   - 'ec2:DescribeSecurityGroups'
                   - 'ec2:RevokeSecurityGroupEgress'
                   - 'ec2:RevokeSecurityGroupIngress'


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-quickstart/quickstart-amazon-eks/issues/191

*Description of changes:*
Authorizes the CleanupLoadBalancers Lambda to detach and delete ENIs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
