### PR TITLE
Add a tag to the EFS: Name=ClusterName to allow users to use the EFS easily

### DIFF
--- a/templates/amazon-eks-efs.template.yaml
+++ b/templates/amazon-eks-efs.template.yaml
@@ -31,7 +31,6 @@ Parameters:
     Default: bursting
   ClusterName:
     Type: String
-    Default: "EKS-EFS"
 Rules:
   ProvisionedThroughput:
     RuleCondition: !Equals [ !Ref ThroughputMode, provisioned ]

--- a/templates/amazon-eks-efs.template.yaml
+++ b/templates/amazon-eks-efs.template.yaml
@@ -57,6 +57,9 @@ Resources:
       PerformanceMode: !Ref PerformanceMode
       ProvisionedThroughputInMibps: !If [ IsProvisioned, !Ref EfsProvisionedThroughputInMibps, !Ref 'AWS::NoValue' ]
       ThroughputMode: !Ref ThroughputMode
+      FileSystemTags:
+        - Key: Name
+          Value: !Ref ClusterName
   MountTargetPrivateSubnet1:
     Type: AWS::EFS::MountTarget
     Properties:

--- a/templates/amazon-eks-efs.template.yaml
+++ b/templates/amazon-eks-efs.template.yaml
@@ -31,6 +31,7 @@ Parameters:
     Default: bursting
   ClusterName:
     Type: String
+    Default: "EKS-EFS"
 Rules:
   ProvisionedThroughput:
     RuleCondition: !Equals [ !Ref ThroughputMode, provisioned ]


### PR DESCRIPTION
Use the tag name with the clusterName parameter to allow users to search the EFS and use the ID with EKS to deploy new pvc or sc.

*Issue #, if available:*
When a user try to create more than one EKS-quickstart cluster with EFS is too dificcult to search what is the EFS deployed for that cluster. If an user wants to use the EFS to add new pvcs is necessary to compare the creation dates when with the ClusterName tag will be easily. 

*Description of changes:*
Add a tag into the EFS template called **Name** with the value: **ClusterName**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
