### PR TITLE
Fix uploading to a custom bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ RESOURCE_PATH ?=
 RESOURCE_TYPE ?=
 REGIONS ?=
 TEST_NAMES ?=
+QSPROD_TEST ?= false
 REGIONAL_STACK ?= true
 ACCOUNT_STACK ?= true
 CLEAN_ACCOUNT ?= true
@@ -30,6 +31,9 @@ build:
 	cp -r LICENSE.txt NOTICE.txt output/build
 	if [ "$(VERSION)" != "" ] ; then \
 	  sed -i "s|Default: $(PREFIX)/|Default: $(PREFIX)-versions/$(VERSION)/|g" output/build/templates/*.yaml ; \
+	fi
+ 	if [ "$(BUCKET)" != "" && QSPROD_TEST == "true" ] ; then \
+ 	  sed -i "s/UsingDefaultBucket: \!Equals \[\!Ref QSS3BucketName, 'aws-quickstart'\]/UsingDefaultBucket: \!Equals [\!Ref QSS3BucketName, \'$(BUCKET)\']/" output/build/templates/*.yaml ; \
 	fi
 	if [ "$(BUCKET)" != "" ] ; then \
 	  sed -i "s/Default: aws-quickstart/Default: $(BUCKET)/" output/build/templates/*.yaml ; \

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ build:
 	  sed -i "s|Default: $(PREFIX)/|Default: $(PREFIX)-versions/$(VERSION)/|g" output/build/templates/*.yaml ; \
 	fi
 	if [ "$(BUCKET)" != "" ] ; then \
-	  sed -i "s/UsingDefaultBucket: \!Equals \[\!Ref QSS3BucketName, 'aws-quickstart'\]/UsingDefaultBucket: \!Equals [\!Ref QSS3BucketName, \'$(BUCKET)\']/" output/build/templates/*.yaml ; \
 	  sed -i "s/Default: aws-quickstart/Default: $(BUCKET)/" output/build/templates/*.yaml ; \
 	fi
 	if [ "$(REGION)" != "" ] ; then \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Building the templates for a custom bucket is currently broken because the make script changes the `UsingDefaultBucket` condition with the name of the custom bucket. This results in the condition being `true` even though it’s not using a default bucket which ends up breaking the nested stacks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
