### PR TITLE
Fix problems with policy name that is always None

### DIFF
--- a/templates/amazon-eks-cluster-autoscaler.template.yaml
+++ b/templates/amazon-eks-cluster-autoscaler.template.yaml
@@ -38,7 +38,7 @@ Resources:
   ClusterAutoScalerPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${NodeAutoScalingGroup}'
+      PolicyName: !Ref EksClusterName
       PolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
*Issue #, if available:*
PolicyName is always None and when an user try to create two eks clusters it fails because has the same name: None

*Description of changes:*
Use EksClusterName to do that

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
