### PR TITLE
s3:GetObject required to pull manifests from s3

### DIFF
--- a/scripts/test-manifest.yaml
+++ b/scripts/test-manifest.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: linux-test-job-from-s3
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
+      containers:
+      - name: test-job
+        image: amazonlinux:2
+        command: ["/bin/bash", "-c", "yum install -y iputils; sleep 120; ping -c 1 aws.amazon.com"]
+      restartPolicy: OnFailure
+  backoffLimit: 4

--- a/templates/amazon-eks-functions.template.yaml
+++ b/templates/amazon-eks-functions.template.yaml
@@ -4,14 +4,9 @@ Metadata:
   QSLint:
     Exclusions: [W9002, W9003, W9004, W9006]
 Parameters:
+  QSS3BucketName:
+    Type: String
   QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/.]*$
-    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), dots(.) and forward slash (/).
-    Default: quickstart-amazon-eks/
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
-      can include numbers, lowercase letters, uppercase letters, hyphens (-), dots(.) and
-      forward slash (/).
     Type: String
   KubernetesAdminRoleArn:
     Type: String
@@ -31,7 +26,20 @@ Mappings:
     Prefix: { Value: 'eks-quickstart' }
 Conditions:
   NoProxy: !Equals [!Ref HttpProxy, '']
+  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
 Resources:
+  CopyZips:
+    Type: Custom::CopyZips
+    Properties:
+      ServiceToken: !Sub ['arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${Prefix}-CopyZips', {Prefix: !FindInMap [Config, Prefix, Value]}]
+      DestBucket: !Sub ['${Prefix}-lambdazips-${AWS::Region}-${AWS::AccountId}', {Prefix: !FindInMap [Config, Prefix, Value]}]
+      SourceBucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      Prefix: !Ref 'QSS3KeyPrefix'
+      Objects:
+        - functions/packages/kubernetesResources/awsqs_kubernetes_get_vpc.zip
+        - functions/packages/kubernetesResources/awsqs_kubernetes_apply_vpc.zip
+        - functions/packages/KubeManifest/lambda.zip
+        - functions/packages/KubeGet/lambda.zip
   LambdaSGCleanup:
     Type: Custom::LambdaSGCleanup
     Properties:
@@ -87,7 +95,7 @@ Resources:
       - Prefix: !FindInMap [Config, Prefix, Value]
       IdField: 'LayerVersionArn'
   KubeGetLambda:
-    DependsOn: LambdaSGCleanup
+    DependsOn: [LambdaSGCleanup, CopyZips]
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub 'awsqs-kubernetes-resource-get-proxy-${EKSClusterName}'
@@ -109,7 +117,7 @@ Resources:
         SecurityGroupIds: [!Ref EKSLambdaSecurityGroup]
         SubnetIds: !Ref EKSSubnetIds
   KubeApplyLambda:
-    DependsOn: LambdaSGCleanup
+    DependsOn: [LambdaSGCleanup, CopyZips]
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub 'awsqs-kubernetes-resource-apply-proxy-${EKSClusterName}'
@@ -132,6 +140,7 @@ Resources:
         SubnetIds: !Ref EKSSubnetIds
   LegacyKubeManifestLambda:
     Type: AWS::Lambda::Function
+    DependsOn: CopyZips
     Properties:
       FunctionName: !Sub "EKS-QuickStart-KubeManifest-${EKSClusterName}"
       Handler: lambda_function.lambda_handler
@@ -154,6 +163,7 @@ Resources:
         SubnetIds: !Ref EKSSubnetIds
   LegacyKubeGetLambda:
     Type: AWS::Lambda::Function
+    DependsOn: CopyZips
     Properties:
       FunctionName: !Sub "EKS-QuickStart-KubeGet-${EKSClusterName}"
       Handler: lambda_function.lambda_handler

--- a/templates/amazon-eks-per-region-resources.template.yaml
+++ b/templates/amazon-eks-per-region-resources.template.yaml
@@ -347,7 +347,8 @@ Resources:
               "sts:GetCallerIdentity",
               "logs:CreateLogGroup",
               "logs:CreateLogStream",
-              "logs:PutLogEvents"
+              "logs:PutLogEvents",
+              "s3:GetObject"
             ]
             Resource: "*"
   CleanupSecurityGroupDependenciesLambda:

--- a/templates/amazon-eks-per-region-resources.template.yaml
+++ b/templates/amazon-eks-per-region-resources.template.yaml
@@ -330,7 +330,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt RegisterTypeFunction.Arn
       TypeName: "AWSQS::Kubernetes::Resource"
-      Version: "3.0.2"
+      Version: "3.0.3"
       SchemaHandlerPackage: !Sub ["s3://${Prefix}-lambdazips-${AWS::Region}-${AWS::AccountId}/${QSS3KeyPrefix}functions/packages/kubernetesResources/awsqs_kubernetes_apply.zip", {Prefix: !FindInMap [Config, Prefix, Value]}]
       IamPolicy:
         Version: '2012-10-17'

--- a/templates/amazon-eks-per-region-resources.template.yaml
+++ b/templates/amazon-eks-per-region-resources.template.yaml
@@ -330,7 +330,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt RegisterTypeFunction.Arn
       TypeName: "AWSQS::Kubernetes::Resource"
-      Version: "3.0.1"
+      Version: "3.0.2"
       SchemaHandlerPackage: !Sub ["s3://${Prefix}-lambdazips-${AWS::Region}-${AWS::AccountId}/${QSS3KeyPrefix}functions/packages/kubernetesResources/awsqs_kubernetes_apply.zip", {Prefix: !FindInMap [Config, Prefix, Value]}]
       IamPolicy:
         Version: '2012-10-17'

--- a/templates/amazon-eks-test.template.yaml
+++ b/templates/amazon-eks-test.template.yaml
@@ -8,6 +8,8 @@ Parameters:
     Type: String
   TestWindows:
     Type: String
+  ManifestUrl:
+    Type: String
 Conditions:
   EnableWindows: !Equals [!Ref TestWindows, 'Enabled']
 Resources:
@@ -18,6 +20,12 @@ Resources:
       Namespace: kube-system
       Name: cm/aws-auth
       JsonPath: '{.data.mapRoles}'
+  TestKubeApplyFromS3:
+    Type: "AWSQS::Kubernetes::Resource"
+    Properties:
+      ClusterName: !Ref ClusterName
+      Namespace: default
+      Url: !Ref ManifestUrl
   TestKubeApply:
     Type: "AWSQS::Kubernetes::Resource"
     Properties:

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -622,6 +622,9 @@ Resources:
       Parameters:
         ClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
         TestWindows: !If [EnableWindows, Enabled, Disabled]
+        ManifestUrl: !Sub
+        - 's3://${S3Bucket}/${QSS3KeyPrefix}/scripts/test-manifest.yaml'
+        - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
   NewRelicStack:
     DependsOn: FunctionStack
     Condition: EnableNewRelic

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -623,7 +623,7 @@ Resources:
         ClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
         TestWindows: !If [EnableWindows, Enabled, Disabled]
         ManifestUrl: !Sub
-        - 's3://${S3Bucket}/${QSS3KeyPrefix}/scripts/test-manifest.yaml'
+        - 's3://${S3Bucket}/${QSS3KeyPrefix}scripts/test-manifest.yaml'
         - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
   NewRelicStack:
     DependsOn: FunctionStack

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -389,6 +389,7 @@ Resources:
         - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
+        QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         KubernetesAdminRoleArn: !GetAtt IamStack.Outputs.KubernetesAdminRoleArn
         ControlPlaneSecurityGroup: !Ref ControlPlaneSecurityGroup


### PR DESCRIPTION
this pr also includes a small fix allowing customers who have launched the eks qs to re-use the regional stack for other projects that depend on the eks quickstart.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
