### PR TITLE
copy zips needs to access other key prefixes when used as submodule

### DIFF
--- a/templates/amazon-eks-per-region-resources.template.yaml
+++ b/templates/amazon-eks-per-region-resources.template.yaml
@@ -55,7 +55,7 @@ Resources:
           Action:
           - s3:PutObject
           - s3:DeleteObject
-          Resource: !Sub 'arn:${AWS::Partition}:s3:::${LambdaZipsBucket}/${QSS3KeyPrefix}*'
+          Resource: !Sub 'arn:${AWS::Partition}:s3:::${LambdaZipsBucket}/*'
   DeleteBucketContentsRolePolicy:
     Type: AWS::IAM::Policy
     Properties:


### PR DESCRIPTION
Other project's re-using the regional/account stacks may need to put objects in different key prefixes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
