### PR TITLE
Added the 'Version' property to the CopyZip resource

### DIFF
--- a/templates/amazon-eks-per-region-resources.template.yaml
+++ b/templates/amazon-eks-per-region-resources.template.yaml
@@ -122,6 +122,7 @@ Resources:
       DestBucket: !Ref LambdaZipsBucket
       SourceBucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Prefix: !Ref 'QSS3KeyPrefix'
+      Version: "1.0.0"
       Objects:
         - functions/packages/DeleteBucketContents/lambda.zip
         - functions/packages/CleanupLoadBalancers/lambda.zip


### PR DESCRIPTION
*Issue #, if available:*
When the stack is already deployed to the AWS account and a new version of a custom resource is released, there is no way to get the updated code from the S3 bucket.

*Description of changes:*
I added the 'Version' property to the CopyZip resource in order to trigger the zip files update when a new custom resource version is released. Of course, this property must be updated every time a new custom resource version is released.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
