### PR TITLE
#265 fix china region can't use the correct image

### DIFF
--- a/templates/amazon-eks-load-balancer-controller.template.yaml
+++ b/templates/amazon-eks-load-balancer-controller.template.yaml
@@ -8,6 +8,52 @@ Parameters:
     Type: String
   EksClusterName:
     Type: String
+Mappings: 
+  RegionMap: 
+    me-south-1:
+      lbrepo: 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon/aws-load-balancer-controller
+    eu-south-1:
+      lbrepo: 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon/aws-load-balancer-controller
+    ap-northeast-1:
+      lbrepo: 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon/aws-load-balancer-controller
+    ap-northeast-2:
+      lbrepo: 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon/aws-load-balancer-controller
+    ap-south-1:
+      lbrepo: 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon/aws-load-balancer-controller
+    ap-southeast-1:
+      lbrepo: 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon/aws-load-balancer-controller
+    ap-southeast-2:
+      lbrepo: 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon/aws-load-balancer-controller
+    ca-central-1:
+      lbrepo: 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon/aws-load-balancer-controller
+    eu-central-1:
+      lbrepo: 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon/aws-load-balancer-controller
+    eu-north-1:
+      lbrepo: 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon/aws-load-balancer-controller
+    eu-west-1:
+      lbrepo: 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon/aws-load-balancer-controller
+    eu-west-2:
+      lbrepo: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon/aws-load-balancer-controller
+    eu-west-3:
+      lbrepo: 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon/aws-load-balancer-controller
+    sa-east-1:
+      lbrepo: 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon/aws-load-balancer-controller
+    us-east-1:
+      lbrepo: 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon/aws-load-balancer-controller
+    us-east-2:
+      lbrepo: 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon/aws-load-balancer-controller
+    us-west-1:
+      lbrepo: 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon/aws-load-balancer-controller
+    us-west-2:
+      lbrepo: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
+    ap-east-1:  
+      lbrepo: 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon/aws-load-balancer-controller
+    af-south-1:
+      lbrepo: 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon/aws-load-balancer-controller
+    cn-north-1:
+      lbrepo: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/amazon/aws-load-balancer-controller
+    cn-northwest-1:
+      lbrepo: 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon/aws-load-balancer-controller
 Resources:
   LoadBalancerControllerIAMRole:
     Type: AWS::IAM::Role
@@ -195,6 +241,8 @@ Resources:
         clusterName: !Ref EksClusterName
         serviceAccount.create: false
         serviceAccount.name: aws-load-balancer-controller
+        region: !Sub '${AWS::Region}'
+        image.repository: !FindInMap [RegionMap, !Ref "AWS::Region", lbrepo]
       ValueYaml: |
         nodeSelector:
           kubernetes.io/os: linux


### PR DESCRIPTION
according the aws-load-balancer-controller released [ecr image list](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases). I added a mapping in the template which make sure the template will pull the image from a correct ecr endpoint. 

fix issue https://github.com/aws-quickstart/quickstart-amazon-eks/issues/265