### PR TITLE
improved cleanup for dangling sg's

### DIFF
--- a/templates/amazon-eks-controlplane.template.yaml
+++ b/templates/amazon-eks-controlplane.template.yaml
@@ -89,6 +89,7 @@ Resources:
       }
   EKS:
     Type: "AWSQS::EKS::Cluster"
+    DependsOn: CleanupLoadBalancers
     Properties:
       Name: !Ref EKSClusterName
       ResourcesVpcConfig:
@@ -154,7 +155,7 @@ Resources:
     Type: Custom::CleanupLoadBalancers
     Properties:
       ServiceToken: !Sub ['arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${Prefix}-CleanupLoadBalancers', {Prefix: !FindInMap [Config, Prefix, Value]}]
-      ClusterName: !Ref EKS
+      ClusterName: !Ref EKSClusterName
   CallerArn:
     Type: Custom::GetCallerArn
     Properties:


### PR DESCRIPTION
In some tests we're seeing vpc fail to delete due to dangling sg's. This should improve cleanup by retying delete after dependencies are cleaned and only starting cleanup after the controlplane is deleted, so it can't try to re-create deleted resources while we're running.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
