### PR TITLE
Switch to cloudformation native OIDCProvider

### DIFF
--- a/templates/amazon-eks-controlplane.template.yaml
+++ b/templates/amazon-eks-controlplane.template.yaml
@@ -162,85 +162,14 @@ Resources:
       ServiceToken: !Sub ['arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${Prefix}-GetCallerArn', {Prefix: !FindInMap [Config, Prefix, Value]}]
   ClusterOIDCProvider:
     Condition: EnableIamOidcProvider
-    Type: Custom::ClusterOIDCProvider
+    Type: AWS::IAM::OIDCProvider
     Properties:
-      ServiceToken: !GetAtt ClusterOIDCProviderFunction.Arn
-      OIDCIssuerURL: !GetAtt EKS.OIDCIssuerURL
-  ClusterOIDCProviderFunction:
-    Condition: EnableIamOidcProvider
-    Type: AWS::Lambda::Function
-    Properties:
-      Runtime: python3.7
-      Handler: index.lambda_handler
-      MemorySize: 128
-      Role: !GetAtt ClusterOIDCLambdaExecutionRole.Arn
-      Timeout: 30
-      Code:
-        ZipFile: |
-          import boto3
-          from botocore.exceptions import ClientError
-          import json
-          import cfnresponse
-          iam = boto3.client("iam")
-          def lambda_handler(event, context):
-            data = {}
-            try:
-              oidc_issuer_url = event['ResourceProperties']['OIDCIssuerURL']
-              if event['RequestType'] == 'Create':
-                # This is the ca thumbprint of AWS's issuer
-                issuer_thumbprint = '9e99a48a9960b14926bb7f3b02e22da2b0ab7280'
-                resp = iam.create_open_id_connect_provider(Url=oidc_issuer_url,ClientIDList=['sts.amazonaws.com'],ThumbprintList=[issuer_thumbprint])
-                provider_arn = resp['OpenIDConnectProviderArn']
-                data["Reason"] = "Provider with ARN " + provider_arn + " created"
-                cfnresponse.send(event, context, cfnresponse.SUCCESS, data, provider_arn)
-              elif event['RequestType'] == 'Delete':
-                provider_arn = event["PhysicalResourceId"]
-                if provider_arn is None:
-                  data["Reason"] = "Provider not present"
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, data, provider_arn)
-                else:
-                  resp = iam.delete_open_id_connect_provider(OpenIDConnectProviderArn=provider_arn)
-                  data["Reason"] = "Provider with ARN " + provider_arn + " deleted"
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, data, provider_arn)
-              else:
-                data["Reason"] = "Unknown operation: " + event['RequestType']
-                cfnresponse.send(event, context, cfnresponse.FAILED, data, "")
-            except Exception as e:
-              data["Reason"] = "Cannot " + event['RequestType'] + " Provider" + str(e)
-              cfnresponse.send(event, context, cfnresponse.FAILED, data, "")
-  ClusterOIDCLambdaExecutionRole:
-    Condition: EnableIamOidcProvider
-    Type: AWS::IAM::Role
-    Properties:
-      Path: /
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      Policies:
-        - PolicyName: root
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-            - Effect: Allow
-              Action:
-              - eks:DescribeCluster
-              Resource: !Sub "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKS}"
-            - Effect: Allow
-              Action:
-              - iam:*OpenIDConnectProvider*
-              Resource: "*"
-            - Effect: Allow
-              Action:
-              - logs:CreateLogGroup
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-              Resource: "*"
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        - 9e99a48a9960b14926bb7f3b02e22da2b0ab7280
+      Url: !GetAtt EKS.OIDCIssuerURL
+
 Outputs:
   EksArn:
     Value: !GetAtt EKS.Arn


### PR DESCRIPTION
*Description of changes:*
Since Cloudformation now supports `AWS::IAM::OIDCProvider` natively we can clean up the work around.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
