### PR TITLE
Do not convert annotation values to booleans

### DIFF
--- a/functions/source/KubeManifest/lambda_function.py
+++ b/functions/source/KubeManifest/lambda_function.py
@@ -104,6 +104,17 @@ def build_output(kube_response):
     return outp
 
 
+def is_sub_path(target_path, path):
+    if len(target_path) > len(path):
+        return False
+
+    for idx, key in enumerate(target_path):
+        if key != path[idx]:
+            return False
+
+    return True
+
+
 def traverse(obj, path=None, callback=None):
     if path is None:
         path = []
@@ -135,8 +146,11 @@ def traverse_modify(obj, target_path, action):
 
 
 def traverse_modify_all(obj, action):
+    annotations = ["metadata", "annotations"]
 
-    def transformer(_, value):
+    def transformer(path, value):
+        if is_sub_path(annotations, path):
+            return value
         return action(value)
     return traverse(obj, callback=transformer)
 


### PR DESCRIPTION
*Issue #, if available:* 304

*Description of changes:*
Add a function to validate if the path is a sub path of target path.
Check if the path is an annotation before applying the transform

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
