### PR TITLE
Add OIDC issuer URL as an output to entry point templates

### DIFF
--- a/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
+++ b/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -747,6 +747,8 @@ Outputs:
     Value: !GetAtt EKSStack.Outputs.NodeGroupSecurityGroup
   ControlPlaneSecurityGroup:
     Value: !GetAtt EKSStack.Outputs.ControlPlaneSecurityGroup
+  OIDCIssuerURL:
+    Value: !GetAtt EKSStack.Outputs.OIDCIssuerURL
 Rules:
   AutoDetectSharedParams:
     RuleCondition: !Or

--- a/templates/amazon-eks-entrypoint-new-vpc.template.yaml
+++ b/templates/amazon-eks-entrypoint-new-vpc.template.yaml
@@ -822,6 +822,8 @@ Outputs:
     Value: !GetAtt EKSStack.Outputs.BastionSecurityGroup
   NodeGroupSecurityGroup:
     Value: !GetAtt EKSStack.Outputs.NodeGroupSecurityGroup
+  OIDCIssuerURL:
+    Value: !GetAtt EKSStack.Outputs.OIDCIssuerURL
 Rules:
   AutoDetectSharedParams:
     RuleCondition: !Or


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Simply exposing output from a nested stack. 

OIDC URL is needed to create IAM roles for service accounts (IRSA). Right now there is no easy way to get the value once the EKS QS stack is deployed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
