### PR TITLE
Pin ALB chart version and adjust IAM policy to handle the latest chart changes

### DIFF
--- a/templates/amazon-eks-load-balancer-controller.template.yaml
+++ b/templates/amazon-eks-load-balancer-controller.template.yaml
@@ -90,6 +90,7 @@ Resources:
                 - 'iam:CreateServiceLinkedRole'
                 - 'ec2:DescribeAccountAttributes'
                 - 'ec2:DescribeAddresses'
+                - 'ec2:DescribeAvailabilityZones'
                 - 'ec2:DescribeInternetGateways'
                 - 'ec2:DescribeVpcs'
                 - 'ec2:DescribeSubnets'
@@ -97,6 +98,8 @@ Resources:
                 - 'ec2:DescribeInstances'
                 - 'ec2:DescribeNetworkInterfaces'
                 - 'ec2:DescribeTags'
+                - 'ec2:GetCoipPoolUsage'
+                - 'ec2:DescribeCoipPools'
                 - 'elasticloadbalancing:DescribeLoadBalancers'
                 - 'elasticloadbalancing:DescribeLoadBalancerAttributes'
                 - 'elasticloadbalancing:DescribeListeners'
@@ -193,6 +196,15 @@ Resources:
                   'aws:ResourceTag/elbv2.k8s.aws/cluster': 'false'
             - Effect: Allow
               Action:
+                - 'elasticloadbalancing:AddTags'
+                - 'elasticloadbalancing:RemoveTags'
+              Resource:
+                - !Sub 'arn:${AWS::Partition}:elasticloadbalancing:*:*:listener/net/*/*/*'
+                - !Sub 'arn:${AWS::Partition}:elasticloadbalancing:*:*:listener/app/*/*/*'
+                - !Sub 'arn:${AWS::Partition}:elasticloadbalancing:*:*:listener-rule/net/*/*/*'
+                - !Sub 'arn:${AWS::Partition}:elasticloadbalancing:*:*:listener-rule/app/*/*/*'
+            - Effect: Allow
+              Action:
                 - 'elasticloadbalancing:ModifyLoadBalancerAttributes'
                 - 'elasticloadbalancing:SetIpAddressType'
                 - 'elasticloadbalancing:SetSecurityGroups'
@@ -241,6 +253,7 @@ Resources:
       Namespace: kube-system
       Repository: https://aws.github.io/eks-charts
       Chart: aws-load-balancer-controller
+      Version: 1.2.3
       Values:
         clusterName: !Ref EksClusterName
         serviceAccount.create: false


### PR DESCRIPTION
*Issue #, if available:*
#320 

*Description of changes:*
The latest ALB controller chart require a change of [IAM policies](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json).

Kudos to @prashilgupta for the patch.
@gargana FYI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
