### PR TITLE
Update kubectl in windows-setup for Kubernetes 1.19

### DIFF
--- a/scripts/windows-setup.sh
+++ b/scripts/windows-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo ${AWS_REGION}
 yum install -y jq  && yum install -y openssl
-curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/kubectl
+curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.6/2021-01-05/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 mv ./kubectl /usr/bin/kubectl
 kubectl apply -f https://amazon-eks.s3.us-west-2.amazonaws.com/manifests/${AWS_REGION}/vpc-resource-controller/latest/vpc-resource-controller.yaml


### PR DESCRIPTION
Corrects an issue whereby trying to sign a CSR thows an error within webhook-create-signed-cert.sh:

No resources found
error: no kind "CertificateSigningRequest" is registered for version "certificates.k8s.io/v1" in scheme "k8s.io/kubernetes/pkg/kubectl/scheme/scheme.go:28"
service/vpc-admission-webhook-svc created

*Description of changes:*
Update kubectl endpoint from v1.15 to v1.19 (as per the default for the quickstart)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
