### PR TITLE
Add support for ap-northeast-3 region

### DIFF
--- a/templates/amazon-eks-load-balancer-controller.template.yaml
+++ b/templates/amazon-eks-load-balancer-controller.template.yaml
@@ -20,6 +20,8 @@ Mappings:
       lbrepo: 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon/aws-load-balancer-controller
     ap-northeast-2:
       lbrepo: 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon/aws-load-balancer-controller
+    ap-northeast-3:
+      lbrepo: 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon/aws-load-balancer-controller
     ap-south-1:
       lbrepo: 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon/aws-load-balancer-controller
     ap-southeast-1:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-quickstart/quickstart-amazon-eks/issues/350

*Description of changes:*
Since `aws-load-balancer-controller` started supporting `ap-northeast-3` region, `quickstart-amazon-eks` should support it as well to be able to deploy LBs in `ap-northeast-3` region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
