### PR TITLE
Values can be of any type

### DIFF
--- a/.override-spec.json
+++ b/.override-spec.json
@@ -258,7 +258,6 @@
           "UpdateType": "Mutable"
         },
         "Values": {
-          "PrimitiveItemType": "String",
           "Type": "Map",
           "Required": false,
           "Documentation": "https://github.com/aws-quickstart/quickstart-helm-resource-provider",


### PR DESCRIPTION
If a chart value is boolean/int cfn-lint will generate errors if we enforce string as type


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
