### PR TITLE
Custom node role support in EKS controlplane template

### DIFF
--- a/templates/amazon-eks-controlplane.template.yaml
+++ b/templates/amazon-eks-controlplane.template.yaml
@@ -21,6 +21,9 @@ Parameters:
   KubernetesVersion:
     Type: String
     Default: ""
+  CustomNodeRole:
+    Type: String
+    Default: ""
   BastionRole:
     Type: String
     Default: ""
@@ -58,6 +61,7 @@ Parameters:
 Conditions:
   AddUser: !Not [ !Equals [ !Ref AdditionalEKSAdminUserArn, "" ] ]
   AddRole: !Not [ !Equals [ !Ref AdditionalEKSAdminRoleArn, "" ] ]
+  CustomeNodeRoleProvided: !Not [ !Equals [ !Ref CustomNodeRole, "" ] ]
   BastionRole: !Not [ !Equals [ !Ref BastionRole, "" ] ]
   EnablePrivateEndpoint: !Equals [ !Ref EKSPrivateAccessEndpoint, "Enabled" ]
   EnablePublicEndpoint: !Equals [ !Ref EKSPublicAccessEndpoint, "Enabled" ]
@@ -119,7 +123,12 @@ Resources:
       Version: !Ref KubernetesVersion
       KubernetesApiAccess:
         Roles:
-          - Arn: !Sub ['arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${Prefix}-UnmanagedNodeInstance', {Prefix: !FindInMap [Config, Prefix, Value]}]
+          - Arn: !Sub
+              - 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${NodeRole}'
+              - NodeRole: !If
+                  - CustomeNodeRoleProvided
+                  - !Ref CustomNodeRole
+                  - !Sub [ '${Prefix}-UnmanagedNodeInstance', { Prefix: !FindInMap [ Config, Prefix, Value ] } ]
             Username: 'system:node:{{EC2PrivateDNSName}}'
             Groups: [ 'system:bootstrappers', 'system:nodes', 'eks:kube-proxy-windows' ]
           - Arn: !Ref FunctionRoleArn


### PR DESCRIPTION
*Issue #, if available:*
#299 - related issue and can be addressed by using the `CustomNodeRole` field added in this PR.

*Description of changes:*
In https://github.com/aws-quickstart/quickstart-cisco-secure-firewall-cloud-native/pull/20 Cisco needs the support of custom node role instead of `role/${Prefix}-UnmanagedNodeInstance`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
