### PR TITLE
Make Key Pair optional in entry templates

### DIFF
--- a/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
+++ b/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -287,6 +287,7 @@ Parameters:
     Description: Name of an existing key pair, which allows you
       to securely connect to your instance after it launches.
     Type: AWS::EC2::KeyPair::KeyName
+    Default: ""
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: Quick Start bucket name can include numbers, lowercase

--- a/templates/amazon-eks-entrypoint-new-vpc.template.yaml
+++ b/templates/amazon-eks-entrypoint-new-vpc.template.yaml
@@ -302,6 +302,7 @@ Parameters:
     Description: Name of an existing key pair, which allows you
       to securely connect to your instance after it launches.
     Type: AWS::EC2::KeyPair::KeyName
+    Default: ""
   PrivateSubnet1CIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16–28


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
```amazon-eks.template.yaml``` template already supports optional key pair but entry templates were not updated accordingly.

@gargana @jaymccon FYI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
