### PR TITLE
Change the type of KeyPair parameter to support empty string as default.

### DIFF
--- a/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
+++ b/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -286,7 +286,7 @@ Parameters:
   KeyPairName:
     Description: Name of an existing key pair, which allows you
       to securely connect to your instance after it launches.
-    Type: AWS::EC2::KeyPair::KeyName
+    Type: String
     Default: ""
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$

--- a/templates/amazon-eks-entrypoint-new-vpc.template.yaml
+++ b/templates/amazon-eks-entrypoint-new-vpc.template.yaml
@@ -301,7 +301,7 @@ Parameters:
   KeyPairName:
     Description: Name of an existing key pair, which allows you
       to securely connect to your instance after it launches.
-    Type: AWS::EC2::KeyPair::KeyName
+    Type: String
     Default: ""
   PrivateSubnet1CIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Further changes to enable EKS deployment without a mandatory key pair. A follow up for #360 

@gargana @jaymccon FYI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
