### PR TITLE
Make Cluster Utilities Available When Logging in via SSM Session Manager

### DIFF
--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -451,6 +451,7 @@ function install_kubernetes_client_tools() {
     mv ./kubectl /usr/local/bin/
     mkdir -p /root/bin
     ln -s /usr/local/bin/kubectl /root/bin/
+    ln -s /usr/local/bin/kubectl /opt/aws/bin
     cat > /etc/profile.d/kubectl.sh <<EOF
 #!/bin/bash
 source <(/usr/local/bin/kubectl completion bash)
@@ -462,6 +463,7 @@ EOF
         tar -xvf helm.tar.gz
         chmod +x ./linux-arm64/helm
         mv ./linux-arm64/helm /usr/local/bin/helm
+        ln -s /usr/local/bin/helm /opt/aws/bin
         rm -rf ./linux-arm64/
 
     elif [[ "${HARDWARE}" == "x86_64" ]]; then
@@ -469,6 +471,7 @@ EOF
         tar -xvf helm.tar.gz
         chmod +x ./linux-amd64/helm
         mv ./linux-amd64/helm /usr/local/bin/helm
+        ln -s /usr/local/bin/helm /opt/aws/bin        
         rm -rf ./linux-amd64/
     fi
 }

--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -437,6 +437,9 @@ EOF
     mkdir -p /root/.kube/
     cp /home/${user}/.kube/config /root/.kube/
     chown -R ${user}:${user_group} /home/${user}/.kube/
+    mkdir -p /home/ssm-user/.kube/
+    cp /home/${user}/.kube/config /home/ssm-user/.kube/config
+    chown -R ssm-user:ssm-user /home/ssm-user/.kube/
 }
 
 function install_kubernetes_client_tools() {


### PR DESCRIPTION
/usr/local/bin and /root/bin are not on the path when doing sudo after using SSM session manager to get to the machine.  The root account context is where the appropriate cluster management permissions are.

*Issue #, if available:* #370

*Description of changes:*

Symlinks kubectl and helm to /opt/aws/bin since it seems to be the only non-system path available after doing an SSM Sessions manager and changing contexts to root. /user/local/bin is not available.
