### PR TITLE
Fix job stabilization by updating the kubernetes resource submodule

### DIFF
--- a/templates/amazon-eks-per-region-resources.template.yaml
+++ b/templates/amazon-eks-per-region-resources.template.yaml
@@ -440,7 +440,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt RegisterTypeFunction.Arn
       TypeName: "AWSQS::Kubernetes::Resource"
-      Version: "3.1.3"
+      Version: "3.1.4"
       RandomStr: !Ref RandomStr
       SchemaHandlerPackage: !Sub ["s3://${Prefix}-lambdazips-${AWS::Region}-${AWS::AccountId}/${QSS3KeyPrefix}functions/packages/kubernetesResources/awsqs_kubernetes_apply.zip", {Prefix: !FindInMap [Config, Prefix, Value]}]
       IamPolicy:

--- a/templates/aws-node-daemonset-IRSA.template.yaml
+++ b/templates/aws-node-daemonset-IRSA.template.yaml
@@ -110,13 +110,14 @@ Resources:
                 kubernetes.io/os: linux
               containers:
               - name: aws-node-enable-irsa
-                image: bitnami/kubectl:1.18
+                image: amazonlinux:2
                 command: ["/bin/bash","-c"]
                 args: 
                   - >
                     sleep 10;
-                    kubectl patch sa aws-node -p '{"metadata": {"annotations": {"eks.amazonaws.com/role-arn": "${AWSNodeIAMRole.Arn}" }}}';
-                    kubectl patch daemonset aws-node -p '{"spec": {"template": {"metadata": {"annotations": {"irsa": "enabled"}}}}}';
+                    curl --retry 5 -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/arm64/kubectl
+                    kubectl -n kube-system patch sa aws-node -p '{"metadata": {"annotations": {"eks.amazonaws.com/role-arn": "${AWSNodeIAMRole.Arn}" }}}';
+                    kubectl -n kube-system patch daemonset aws-node -p '{"spec": {"template": {"metadata": {"annotations": {"irsa": "enabled"}}}}}';
                     RETRIES=0 ;
                     while true ; do
                       DESIRED=$(kubectl get daemonset aws-node -n kube-system -o jsonpath={.status.desiredNumberScheduled});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Job stabilization relied on a deprecated(and removed in newer versions) kubernetes manifest property `selfLink`.
Adjust code to rely on `uid` instead.
Bump the version for the Resource Type in the Regional Shared resources template to ensure deployments of new version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
