### PR TITLE
Locked Semantic_version module to specific version

### DIFF
--- a/functions/source/registerCustomResource/requirements.txt
+++ b/functions/source/registerCustomResource/requirements.txt
@@ -1,1 +1,1 @@
-semantic_version
+semantic_version==2.8.5


### PR DESCRIPTION
semantic_version==2.8.5

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
