### PR TITLE
Add CloudWatchAgentServerPolicy to ManagedNodeInstanceRole in the Account Shared Resources stack

### DIFF
--- a/templates/amazon-eks-per-account-resources.template.yaml
+++ b/templates/amazon-eks-per-account-resources.template.yaml
@@ -603,6 +603,7 @@ Resources:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonElasticFileSystemReadOnlyAccess'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
   CloudformationVPCRoleCreationRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
* Amazon CloudWatch Container Insights prerequisite
* The workaround currently used in the GitLab QS causes an unintended account-level cluster limit due to the role's policy length limit.

*Issue #, if available:*
* https://github.com/aws-quickstart/quickstart-eks-gitlab/pull/134


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
