### PR TITLE
Bump Linux bastion submodule to latest and add SSM-only remote access option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,29 @@
-/.idea
-/taskcat_outputs
-/venv
-/.venv
-.DS_Store
-/.taskcat
-/functions/packages
-/output
+# TaskCat
+taskcat_outputs/
+.taskcat/
+.taskcat_overrides.yml
+functions/packages/
+*.zip
+output/
+
+# Docs
+## Docs 2.1+
+# docs/
+## Docs 2.0
+docs/generated/
+index.html
+prod_example.html
+
+# Python
 __pycache__
-/docs/generated/
-/index.html
-/.python-version
-/.taskcat_overrides.yml
+.python-version
+venv/
+.venv/
+env/
+
+# macOS
+.DS_Store
+
+# IDE workspace settings
+.vscode/
+.idea/

--- a/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
+++ b/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -338,10 +338,15 @@ Parameters:
       hosted. When using your own bucket, you must specify this value.
     Type: String
   RemoteAccessCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
-    Description: CIDR IP range that is permitted to access the instances. We recommend that you set this value to a trusted IP range.
     Type: String
+    Description: >-
+      Trusted IPv4 CIDR block that is permitted remote access to your instances
+      if desired in addition to AWS Systems Manager (SSM) access.
+    AllowedPattern: ^(disabled-onlyssmaccess|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2])))$
+    ConstraintDescription: >-
+      CIDR block parameter must be disabled-onlyssmaccess or in the form
+      x.x.x.x/x.
+    Default: disabled-onlyssmaccess
   EKSPublicAccessEndpoint:
     Type: String
     AllowedValues: [Enabled, Disabled]
@@ -1197,6 +1202,7 @@ Conditions:
   CreateAdvancedConfigWithDefaults: !Equals [!Ref ConfigSetName, '']
   CreatePerAccountSharedResources: !Equals [!Ref PerAccountSharedResources, 'Yes']
   CreatePerRegionSharedResources: !Equals [!Ref PerRegionSharedResources, 'Yes']
+  OnlySsmAccess: !Equals [!Ref RemoteAccessCIDR, disabled-onlyssmaccess]
   WindowsNodes: !Equals [!Ref NodeGroupOS, 'Windows']
   VaultEnabled: !Equals [!Ref VaultIntegration, 'Enabled']
   EnablePrometheus: !Or
@@ -1262,8 +1268,8 @@ Resources:
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         ConfigSetName: !Ref AWS::StackName
-        ConsulUIAccessCIDR: !Ref RemoteAccessCIDR
-        VaultUIAccessCIDR: !Ref RemoteAccessCIDR
+        ConsulUIAccessCIDR: !If [OnlySsmAccess, 127.0.0.1/32, !Ref RemoteAccessCIDR]
+        VaultUIAccessCIDR: !If [OnlySsmAccess, 127.0.0.1/32, !Ref RemoteAccessCIDR]
         NodeVolumeSize: !If [WindowsNodes, 50, !Ref 'AWS::NoValue']
         KubernetesVersion: !If [VaultEnabled, '1.17', !Ref 'AWS::NoValue']
   EKSStack:

--- a/templates/amazon-eks-entrypoint-new-vpc.template.yaml
+++ b/templates/amazon-eks-entrypoint-new-vpc.template.yaml
@@ -392,11 +392,15 @@ Parameters:
       hosted. When using your own bucket, you must specify this value.
     Type: String
   RemoteAccessCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
-    Description: CIDR IP range that is permitted to access the instances. We recommend
-      that you set this value to a trusted IP range.
     Type: String
+    Description: >-
+      Trusted IPv4 CIDR block that is permitted remote access to your instances
+      if desired in addition to AWS Systems Manager (SSM) access.
+    AllowedPattern: ^(disabled-onlyssmaccess|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2])))$
+    ConstraintDescription: >-
+      CIDR block parameter must be disabled-onlyssmaccess or in the form
+      x.x.x.x/x.
+    Default: disabled-onlyssmaccess
   EKSPublicAccessEndpoint:
     Type: String
     AllowedValues: [Enabled, Disabled]
@@ -1245,6 +1249,7 @@ Conditions:
   2AZDeployment: !Or
     - !Equals [!Ref NumberOfAZs, "2"]
     - !Equals [!Ref NumberOfAZs, "3"]
+  OnlySsmAccess: !Equals [!Ref RemoteAccessCIDR, disabled-onlyssmaccess]
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   WindowsNodes: !Equals [!Ref NodeGroupOS, 'Windows']
   VaultEnabled: !Equals [!Ref VaultIntegration, 'Enabled']
@@ -1267,8 +1272,8 @@ Resources:
         # As of 08/03/2021 there are no eks optimized ami's for eks 1.21
         # TODO: remove forcing windows clusters to 1.20 once ami's are available https://github.com/aws/containers-roadmap/issues/1461
         KubernetesVersion: !If [VaultEnabled, '1.17', !If [WindowsNodes, '1.20', !Ref 'AWS::NoValue']]
-        ConsulUIAccessCIDR: !Ref RemoteAccessCIDR
-        VaultUIAccessCIDR: !Ref RemoteAccessCIDR
+        ConsulUIAccessCIDR: !If [OnlySsmAccess, 127.0.0.1/32, !Ref RemoteAccessCIDR]
+        VaultUIAccessCIDR: !If [OnlySsmAccess, 127.0.0.1/32, !Ref RemoteAccessCIDR]
   AutoDetectSharedResources:
     Type: AWS::CloudFormation::Stack
     Condition: DetectSharedStacks

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -23,8 +23,12 @@ Parameters:
       hosted. When using your own bucket, you must specify this value.
     Type: String
   RemoteAccessCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     Type: String
+    AllowedPattern: ^(disabled-onlyssmaccess|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2])))$
+    ConstraintDescription: >-
+      CIDR block parameter must be disabled-onlyssmaccess or in the form
+      x.x.x.x/x.
+    Default: disabled-onlyssmaccess
   EKSPublicAccessEndpoint:
     Type: String
     AllowedValues: [Enabled, Disabled]

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -339,7 +339,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub
-        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-linux-bastion/templates/linux-bastion.template'
+        - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-linux-bastion/templates/linux-bastion-entrypoint-existing-vpc.template.yaml
         - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -344,23 +344,23 @@ Resources:
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-linux-bastion/templates/linux-bastion-entrypoint-existing-vpc.template.yaml
-        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+        - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         BastionHostName: EKSBastion
         BastionBanner: !Sub
-          - 's3://${S3Bucket}/${QSS3KeyPrefix}scripts/bastion_banner_message.txt'
+          - s3://${S3Bucket}/${QSS3KeyPrefix}scripts/bastion_banner_message.txt
           - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
         EnableBanner: true
         BastionTenancy: default
-        NumBastionHosts: "1"
+        NumBastionHosts: 1
         OSImageOverride: !Ref BastionAMIID
         VPCID: !Ref VPCID
         PublicSubnet1ID: !Ref PublicSubnet1ID
-        PublicSubnet2ID: !If [2AZDeployment, !Ref PublicSubnet2ID, !Ref "AWS::NoValue"]
+        PublicSubnet2ID: !If [2AZDeployment, !Ref PublicSubnet2ID, !Ref AWS::NoValue]
         KeyPairName: !Ref KeyPairName
         QSS3BucketName: !Ref QSS3BucketName
-        QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}submodules/quickstart-linux-bastion/'
+        QSS3KeyPrefix: !Sub ${QSS3KeyPrefix}submodules/quickstart-linux-bastion/
         QSS3BucketRegion: !Ref QSS3BucketRegion
         RemoteAccessCIDR: !Ref RemoteAccessCIDR
         BastionInstanceType: ~~/<ConfigSetName>/bastion/BastionInstanceType~~
@@ -368,8 +368,8 @@ Resources:
         AlternativeInitializationScript: !If
           - DefaultBastionBootstrap
           - !Sub
-            - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}scripts/bastion_bootstrap.sh'
-            - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+            - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}scripts/bastion_bootstrap.sh
+            - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
               S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
           - ~~/<ConfigSetName>/bastion/BastionBootstrapScript~~
         AlternativeIAMRole: !GetAtt IamStack.Outputs.BastionRole
@@ -383,7 +383,7 @@ Resources:
           K8S_VERSION=${KubernetesVersion},
           K8S_ENDPOINT=${EKSControlPlane.Outputs.EKSEndpoint}${Joiner}
           ${BastionVariables}
-        - Joiner: !If [AdditionalVars, ",", ""]
+        - Joiner: !If [AdditionalVars, ',', '']
           BastionVariables: ~~/<ConfigSetName>/bastion/BastionVariables~~
           KubernetesVersion: ~~/<ConfigSetName>/controlplane/KubernetesVersion~~
   NodeGroupStack:


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/aws-quickstart/quickstart-eks-gitlab/issues/103
* https://github.com/aws-quickstart/quickstart-amazon-eks/pull/442
* https://github.com/aws-quickstart/quickstart-linux-bastion/pull/142

*Description of changes:*
* Bump Linux bastion submodule to latest
* Add SSM-only remote access option
* Update gitignore to ignore artifacts, et cetera


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
