### PR TITLE
Add missing permission and use distinct role for VPC proxy function

### DIFF
--- a/templates/amazon-eks-entrypoint-existing-cluster.template.yaml
+++ b/templates/amazon-eks-entrypoint-existing-cluster.template.yaml
@@ -195,6 +195,7 @@ Resources:
       Parameters:
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        KubernetesResourceVPCProxyRoleArn: !GetAtt IamStack.Outputs.KubernetesResourceVPCProxyRoleArn
         KubernetesAdminRoleArn: !GetAtt IamStack.Outputs.KubernetesAdminRoleArn
         ControlPlaneSecurityGroup: !Ref ControlPlaneSecurityGroup
         VPCID: !Ref VPCID

--- a/templates/amazon-eks-entrypoint-existing-cluster.template.yaml
+++ b/templates/amazon-eks-entrypoint-existing-cluster.template.yaml
@@ -193,7 +193,6 @@ Resources:
         - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
-        QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         KubernetesResourceVPCProxyRoleArn: !GetAtt IamStack.Outputs.KubernetesResourceVPCProxyRoleArn
         KubernetesAdminRoleArn: !GetAtt IamStack.Outputs.KubernetesAdminRoleArn

--- a/templates/amazon-eks-per-region-resources.template.yaml
+++ b/templates/amazon-eks-per-region-resources.template.yaml
@@ -275,6 +275,7 @@ Resources:
               - iam:PassRole
               - sts:AssumeRole
               - lambda:UpdateFunctionConfiguration
+              - lambda:GetFunctionConfiguration
               - lambda:DeleteFunction
               - lambda:GetFunction
               - lambda:InvokeFunction

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -510,6 +510,7 @@ Resources:
       Parameters:
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         KubernetesAdminRoleArn: !GetAtt IamStack.Outputs.KubernetesAdminRoleArn
+        KubernetesResourceVPCProxyRoleArn: !GetAtt IamStack.Outputs.KubernetesResourceVPCProxyRoleArn
         ControlPlaneSecurityGroup: !Ref ControlPlaneSecurityGroup
         VPCID: !Ref VPCID
         EKSSubnetIds: !If

--- a/templates/workloads/amazon-eks-functions.template.yaml
+++ b/templates/workloads/amazon-eks-functions.template.yaml
@@ -8,6 +8,8 @@ Parameters:
     Type: String
   KubernetesAdminRoleArn:
     Type: String
+  KubernetesResourceVPCProxyRoleArn:
+    Type: String
   VPCID:
     Type: AWS::EC2::VPC::Id
   ControlPlaneSecurityGroup:
@@ -75,7 +77,7 @@ Resources:
       FunctionName: !Sub awsqs-kubernetes-resource-proxy-${EKSClusterName}
       Handler: awsqs_kubernetes_resource.utils.proxy_wrap
       MemorySize: 256
-      Role: !Ref KubernetesAdminRoleArn
+      Role: !Ref KubernetesResourceVPCProxyRoleArn
       Runtime: python3.8
       Timeout: 900
       Code:

--- a/templates/workloads/amazon-eks-functions.template.yaml
+++ b/templates/workloads/amazon-eks-functions.template.yaml
@@ -77,7 +77,7 @@ Resources:
       FunctionName: !Sub awsqs-kubernetes-resource-proxy-${EKSClusterName}
       Handler: awsqs_kubernetes_resource.utils.proxy_wrap
       MemorySize: 256
-      Role: !Ref KubernetesResourceVPCProxyRoleArn
+      Role: !Ref KubernetesAdminRoleArn
       Runtime: python3.8
       Timeout: 900
       Code:

--- a/templates/workloads/amazon-eks-iam.template.yaml
+++ b/templates/workloads/amazon-eks-iam.template.yaml
@@ -159,6 +159,13 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                  - ec2:CreateNetworkInterface
+                  - ec2:DeleteNetworkInterface
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:*/*
+                  # https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html#vpc-permissions
+              - Effect: Allow
+                Action:
                   - sts:GetCallerIdentity
                   - eks:CreateCluster
                   - eks:DeleteCluster

--- a/templates/workloads/amazon-eks-iam.template.yaml
+++ b/templates/workloads/amazon-eks-iam.template.yaml
@@ -118,8 +118,14 @@ Resources:
                   - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*/* # Custom event bus
               - Effect: Allow
                 Action:
-                  - lambda:AddPermission
+                  - lambda:UpdateFunctionConfiguration
+                  - lambda:GetFunctionConfiguration
+                  - lambda:DeleteFunction
+                  - lambda:GetFunction
                   - lambda:InvokeFunction
+                  - lambda:CreateFunction
+                  - lambda:UpdateFunctionCode
+                  - lambda:AddPermission
                   - lambda:RemovePermission
                 Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*
               - Effect: Allow

--- a/templates/workloads/amazon-eks-iam.template.yaml
+++ b/templates/workloads/amazon-eks-iam.template.yaml
@@ -133,6 +133,63 @@ Resources:
               - Effect: Allow
                 Action: s3:GetObject
                 Resource: !Sub arn:${AWS::Partition}:s3:::*/*
+  KubernetesResourceVPCProxyRole:
+    Type: AWS::IAM::Role
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [ EIAMPolicyWildcardResource ]
+          ignore_reasons:
+            EIAMPolicyWildcardResource: >-
+              Action eks:DescribeAddonConfiguration requires a wildcard
+              resource. As of 2023-02-05, cfn-lint falsely reports this as an
+              issue.
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: eksStackPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sts:GetCallerIdentity
+                  - eks:CreateCluster
+                  - eks:DeleteCluster
+                  - eks:DescribeCluster
+                  - eks:ListTagsForResource
+                  - eks:UpdateClusterVersion
+                  - eks:UpdateClusterConfig
+                  - eks:TagResource
+                  - eks:UntagResource
+                  - iam:PassRole
+                  - sts:AssumeRole
+                  - lambda:UpdateFunctionConfiguration
+                  - lambda:GetFunctionConfiguration
+                  - lambda:DeleteFunction
+                  - lambda:GetFunction
+                  - lambda:InvokeFunction
+                  - lambda:CreateFunction
+                  - lambda:UpdateFunctionCode
+                  - ec2:DescribeVpcs
+                  - ec2:DescribeSubnets
+                  - ec2:DescribeSecurityGroups
+                  - kms:CreateGrant
+                  - kms:DescribeKey
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:DescribeLogGroups
+                  - logs:DescribeLogStreams
+                  - logs:PutLogEvents
+                  - cloudwatch:ListMetrics
+                  - cloudwatch:PutMetricData
+                Resource: '*'
   BastionRole:
     Condition: EnableBastionRole
     Type: AWS::IAM::Role
@@ -187,6 +244,8 @@ Resources:
       ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:eks-quickstart-CloudFormationVPCRoleCreation
       Partition: !Ref AWS::Partition
 Outputs:
+  KubernetesResourceVPCProxyRoleArn:
+    Value: !GetAtt KubernetesResourceVPCProxyRole.Arn
   KubernetesAdminRoleArn:
     Value: !GetAtt KubernetesAdminRole.Arn
   BastionRole:

--- a/templates/workloads/amazon-eks.template.yaml
+++ b/templates/workloads/amazon-eks.template.yaml
@@ -510,6 +510,7 @@ Resources:
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        KubernetesResourceVPCProxyRoleArn: !GetAtt IamStack.Outputs.KubernetesResourceVPCProxyRoleArn
         KubernetesAdminRoleArn: !GetAtt IamStack.Outputs.KubernetesAdminRoleArn
         ControlPlaneSecurityGroup: !Ref ControlPlaneSecurityGroup
         VPCID: !Ref VPCID


### PR DESCRIPTION
*Description of changes:*
Add missing IAM permission to AWSQS::Kubernetes::Resource IAM Role.
Create a distinct IAM policy for the AWSQS::Kubernetes::Resource VPC proxy lambda

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
