### PR TITLE
Add parameter to skip node group creation

### DIFF
--- a/templates/amazon-eks-advanced-configuration.template.yaml
+++ b/templates/amazon-eks-advanced-configuration.template.yaml
@@ -47,6 +47,7 @@ Metadata:
           - EC2MetadataHttpTokens
           - MaxNodesUnavailable
           - MaxNodesUnavailablePercentage
+          - CreateNodeGroup
       - Label:
           default: Bastion configuration
         Parameters:
@@ -142,6 +143,8 @@ Metadata:
         default: Max nodes unavailable
       MaxNodesUnavailablePercentage:
         default: Max nodes unavailable percentage
+      CreateNodeGroup:
+        default: Create node group
 Parameters:
   ConfigSetName:
     Type: String
@@ -443,6 +446,14 @@ Parameters:
     MinValue: 0
     MaxValue: 100
     Default: 0
+  CreateNodeGroup:
+    Type: String
+    Description: >-
+      If set to "No" the node group stack will create just the Security Group
+      skipping the node group. This is useful if you manage the node group with
+      third party integration, such as Spot.io.
+    AllowedValues: ['Yes', 'No']
+    Default: 'Yes'
 Mappings:
   KubernetesVersion:
   # https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
@@ -690,6 +701,12 @@ Resources:
       Type: String
       Name: !Sub /quickstart/amazon-eks/${ConfigSetName}/default-nodegroup/MaxNodesUnavailablePercentage
       Value: !Sub '{ "Value": "${MaxNodesUnavailablePercentage}" }'
+  CreateNodeGroupParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Name: !Sub /quickstart/amazon-eks/${ConfigSetName}/default-nodegroup/CreateNodeGroup
+      Value: !Sub '{ "Value": "${CreateNodeGroup}" }'
 Outputs:
   ConfigSetName:
     Description: Config set name.

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -321,7 +321,10 @@ Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, aws-quickstart]
   GenerateClusterName: !Equals [!Ref EKSClusterName, '']
   UseKeyPair: !Not [!Equals [!Ref KeyPairName, '']]
-  UseUnmanagedNodeGroup: !Equals [!Ref NodeGroupType, Unmanaged]
+  CreateNodeGroup: !Equals [~~/<ConfigSetName>/default-nodegroup/CreateNodeGroup~~, 'Yes']
+  CreateUnmanagedNodeGroup: !And
+    - !Equals [!Ref NodeGroupType, Unmanaged]
+    - !Condition CreateNodeGroup
 Resources:
   BastionEksPermissions:
     Type: AWS::IAM::Policy
@@ -431,6 +434,7 @@ Resources:
         EC2MetadataHttpTokens: ~~/<ConfigSetName>/default-nodegroup/EC2MetadataHttpTokens~~
         MaxNodesUnavailable: ~~/<ConfigSetName>/default-nodegroup/MaxNodesUnavailable~~
         MaxNodesUnavailablePercentage: ~~/<ConfigSetName>/default-nodegroup/MaxNodesUnavailablePercentage~~
+        CreateNodeGroup: ~~/<ConfigSetName>/default-nodegroup/CreateNodeGroup~~
   WindowsSupportNodeGroupStack:
     Type: AWS::CloudFormation::Stack
     Condition: EnableWindows
@@ -536,8 +540,8 @@ Resources:
       Parameters:
         EksClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
         KubernetesVersion: ~~/<ConfigSetName>/controlplane/KubernetesVersion~~
-        OIDCProviderArn: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderArn
-        OIDCProviderEndpoint: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint
+        OIDCProviderArn: !GetAtt EKSControlPlane.Outputs.OIDCProviderArn
+        OIDCProviderEndpoint: !GetAtt EKSControlPlane.Outputs.OIDCProviderEndpoint
         PrometheusEnabled: !If [EnablePrometheus, 'true', 'false']
         PrometheusNamespace: !FindInMap [Config, Namespace, Prometheus]
   MetricsServerStack:
@@ -555,8 +559,8 @@ Resources:
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         EksClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
-        OIDCProviderArn: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderArn
-        OIDCProviderEndpoint: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint
+        OIDCProviderArn: !GetAtt EKSControlPlane.Outputs.OIDCProviderArn
+        OIDCProviderEndpoint: !GetAtt EKSControlPlane.Outputs.OIDCProviderEndpoint
   EfsStack:
     Type: AWS::CloudFormation::Stack
     Condition: EnableEfs
@@ -710,8 +714,8 @@ Resources:
         - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
-        OIDCProviderArn: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderArn
-        OIDCProviderEndpoint: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint
+        OIDCProviderArn: !GetAtt EKSControlPlane.Outputs.OIDCProviderArn
+        OIDCProviderEndpoint: !GetAtt EKSControlPlane.Outputs.OIDCProviderEndpoint
         EksClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
         VpcId: !Ref VPCID
   GenerateClusterName:
@@ -879,6 +883,7 @@ Resources:
       ClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
   AwsNodeIrsaStack:
     Type: AWS::CloudFormation::Stack
+    Condition: CreateNodeGroup
     DependsOn: NodeGroupStack
     Properties:
       TemplateURL: !Sub
@@ -900,16 +905,16 @@ Resources:
             {
               "Effect": "Allow",
               "Principal": {
-                "Federated": "${AwsNodeIrsaStack.Outputs.OIDCProviderArn}"
+                "Federated": "${EKSControlPlane.Outputs.OIDCProviderArn}"
               },
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringEquals": {
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:aud": [
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:aud": [
                     "sts.amazonaws.com",
                     "sts.${AWS::Region}.amazonaws.com"
                   ],
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
                 }
               }
             }
@@ -959,7 +964,7 @@ Resources:
       ServiceAccountRoleArn: !GetAtt AmazonEksEbsCsiDriverRole.Arn
   AwsNodeTerminationHandlerRole:
     Type: AWS::IAM::Role
-    Condition: UseUnmanagedNodeGroup
+    Condition: CreateUnmanagedNodeGroup
     Properties:
       AssumeRolePolicyDocument: !Sub |
         {
@@ -968,16 +973,16 @@ Resources:
             {
               "Effect": "Allow",
               "Principal": {
-                "Federated": "${AwsNodeIrsaStack.Outputs.OIDCProviderArn}"
+                "Federated": "${EKSControlPlane.Outputs.OIDCProviderArn}"
               },
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringEquals": {
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:aud": [
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:aud": [
                     "sts.amazonaws.com",
                     "sts.${AWS::Region}.amazonaws.com"
                   ],
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:aws-node-termination-handler"
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:aws-node-termination-handler"
                 }
               }
             }
@@ -991,7 +996,7 @@ Resources:
     # https://artifacthub.io/packages/helm/aws/aws-node-termination-handler
     # https://github.com/aws/eks-charts/tree/master/stable/aws-node-termination-handler
     Type: AWSQS::Kubernetes::Helm
-    Condition: UseUnmanagedNodeGroup
+    Condition: CreateUnmanagedNodeGroup
     Properties:
       ClusterID: !GetAtt EKSControlPlane.Outputs.EKSName
       Namespace: kube-system
@@ -1034,16 +1039,16 @@ Resources:
             {
               "Effect": "Allow",
               "Principal": {
-                "Federated": "${AwsNodeIrsaStack.Outputs.OIDCProviderArn}"
+                "Federated": "${EKSControlPlane.Outputs.OIDCProviderArn}"
               },
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringEquals": {
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:aud": [
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:aud": [
                     "sts.amazonaws.com",
                     "sts.${AWS::Region}.amazonaws.com"
                   ],
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:efs-csi-controller-sa"
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:efs-csi-controller-sa"
                 }
               }
             }

--- a/templates/amazon-eks.template.yaml
+++ b/templates/amazon-eks.template.yaml
@@ -1039,16 +1039,16 @@ Resources:
             {
               "Effect": "Allow",
               "Principal": {
-                "Federated": "${EKSControlPlane.Outputs.OIDCProviderArn}"
+                "Federated": "${AwsNodeIrsaStack.Outputs.OIDCProviderArn}"
               },
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringEquals": {
-                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:aud": [
+                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:aud": [
                     "sts.amazonaws.com",
                     "sts.${AWS::Region}.amazonaws.com"
                   ],
-                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:efs-csi-controller-sa"
+                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:efs-csi-controller-sa"
                 }
               }
             }

--- a/templates/workloads/amazon-eks.template.yaml
+++ b/templates/workloads/amazon-eks.template.yaml
@@ -1063,16 +1063,16 @@ Resources:
             {
               "Effect": "Allow",
               "Principal": {
-                "Federated": "${EKSControlPlane.Outputs.OIDCProviderArn}"
+                "Federated": "${AwsNodeIrsaStack.Outputs.OIDCProviderArn}"
               },
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringEquals": {
-                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:aud": [
+                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:aud": [
                     "sts.amazonaws.com",
                     "sts.${AWS::Region}.amazonaws.com"
                   ],
-                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:efs-csi-controller-sa"
+                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:efs-csi-controller-sa"
                 }
               }
             }

--- a/templates/workloads/amazon-eks.template.yaml
+++ b/templates/workloads/amazon-eks.template.yaml
@@ -322,7 +322,10 @@ Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, aws-quickstart]
   GenerateClusterName: !Equals [!Ref EKSClusterName, '']
   UseKeyPair: !Not [!Equals [!Ref KeyPairName, '']]
-  UseUnmanagedNodeGroup: !Equals [!Ref NodeGroupType, Unmanaged]
+  CreateNodeGroup: !Equals [~~/<ConfigSetName>/default-nodegroup/CreateNodeGroup~~, 'Yes']
+  CreateUnmanagedNodeGroup: !And
+    - !Equals [!Ref NodeGroupType, Unmanaged]
+    - !Condition CreateNodeGroup
 Resources:
   BastionEksPermissions:
     Type: AWS::IAM::Policy
@@ -433,6 +436,7 @@ Resources:
         EC2MetadataHttpTokens: ~~/<ConfigSetName>/default-nodegroup/EC2MetadataHttpTokens~~
         MaxNodesUnavailable: ~~/<ConfigSetName>/default-nodegroup/MaxNodesUnavailable~~
         MaxNodesUnavailablePercentage: ~~/<ConfigSetName>/default-nodegroup/MaxNodesUnavailablePercentage~~
+        CreateNodeGroup: ~~/<ConfigSetName>/default-nodegroup/CreateNodeGroup~~
   WindowsSupportNodeGroupStack:
     Type: AWS::CloudFormation::Stack
     Condition: EnableWindows
@@ -538,8 +542,8 @@ Resources:
       Parameters:
         EksClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
         KubernetesVersion: ~~/<ConfigSetName>/controlplane/KubernetesVersion~~
-        OIDCProviderArn: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderArn
-        OIDCProviderEndpoint: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint
+        OIDCProviderArn: !GetAtt EKSControlPlane.Outputs.OIDCProviderArn
+        OIDCProviderEndpoint: !GetAtt EKSControlPlane.Outputs.OIDCProviderEndpoint
   MetricsServerStack:
     Type: AWS::CloudFormation::Stack
     Condition: EnableMetricsServer
@@ -555,8 +559,8 @@ Resources:
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         EksClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
-        OIDCProviderArn: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderArn
-        OIDCProviderEndpoint: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint
+        OIDCProviderArn: !GetAtt EKSControlPlane.Outputs.OIDCProviderArn
+        OIDCProviderEndpoint: !GetAtt EKSControlPlane.Outputs.OIDCProviderEndpoint
   EfsStack:
     Type: AWS::CloudFormation::Stack
     Condition: EnableEfs
@@ -712,8 +716,8 @@ Resources:
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         EksClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
-        OIDCProviderArn: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderArn
-        OIDCProviderEndpoint: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint
+        OIDCProviderArn: !GetAtt EKSControlPlane.Outputs.OIDCProviderArn
+        OIDCProviderEndpoint: !GetAtt EKSControlPlane.Outputs.OIDCProviderEndpoint
         PrometheusEnabled: !If [EnablePrometheus, 'true', 'false']
         FargateEnabled: !If [EnableFargate, 'true', 'false']
   LoadBalancerStack:
@@ -731,8 +735,8 @@ Resources:
         - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
-        OIDCProviderArn: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderArn
-        OIDCProviderEndpoint: !GetAtt AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint
+        OIDCProviderArn: !GetAtt EKSControlPlane.Outputs.OIDCProviderArn
+        OIDCProviderEndpoint: !GetAtt EKSControlPlane.Outputs.OIDCProviderEndpoint
         EksClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
         VpcId: !Ref VPCID
   GenerateClusterName:
@@ -900,6 +904,7 @@ Resources:
       ClusterName: !GetAtt EKSControlPlane.Outputs.EKSName
   AwsNodeIrsaStack:
     Type: AWS::CloudFormation::Stack
+    Condition: CreateNodeGroup
     DependsOn: NodeGroupStack
     Properties:
       TemplateURL: !Sub
@@ -921,16 +926,16 @@ Resources:
             {
               "Effect": "Allow",
               "Principal": {
-                "Federated": "${AwsNodeIrsaStack.Outputs.OIDCProviderArn}"
+                "Federated": "${EKSControlPlane.Outputs.OIDCProviderArn}"
               },
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringEquals": {
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:aud": [
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:aud": [
                     "sts.amazonaws.com",
                     "sts.${AWS::Region}.amazonaws.com"
                   ],
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
                 }
               }
             }
@@ -980,7 +985,7 @@ Resources:
       ServiceAccountRoleArn: !GetAtt AmazonEksEbsCsiDriverRole.Arn
   AwsNodeTerminationHandlerRole:
     Type: AWS::IAM::Role
-    Condition: UseUnmanagedNodeGroup
+    Condition: CreateUnmanagedNodeGroup
     Properties:
       AssumeRolePolicyDocument: !Sub |
         {
@@ -989,16 +994,16 @@ Resources:
             {
               "Effect": "Allow",
               "Principal": {
-                "Federated": "${AwsNodeIrsaStack.Outputs.OIDCProviderArn}"
+                "Federated": "${EKSControlPlane.Outputs.OIDCProviderArn}"
               },
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringEquals": {
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:aud": [
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:aud": [
                     "sts.amazonaws.com",
                     "sts.${AWS::Region}.amazonaws.com"
                   ],
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:aws-node-termination-handler"
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:aws-node-termination-handler"
                 }
               }
             }
@@ -1012,7 +1017,7 @@ Resources:
     # https://artifacthub.io/packages/helm/aws/aws-node-termination-handler
     # https://github.com/aws/eks-charts/tree/master/stable/aws-node-termination-handler
     Type: AWSQS::Kubernetes::Helm
-    Condition: UseUnmanagedNodeGroup
+    Condition: CreateUnmanagedNodeGroup
     Metadata:
       DependsOn:
         - !If [EnablePrometheus, !Ref PrometheusStack, !Ref AWS::NoValue]
@@ -1058,16 +1063,16 @@ Resources:
             {
               "Effect": "Allow",
               "Principal": {
-                "Federated": "${AwsNodeIrsaStack.Outputs.OIDCProviderArn}"
+                "Federated": "${EKSControlPlane.Outputs.OIDCProviderArn}"
               },
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringEquals": {
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:aud": [
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:aud": [
                     "sts.amazonaws.com",
                     "sts.${AWS::Region}.amazonaws.com"
                   ],
-                  "${AwsNodeIrsaStack.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:efs-csi-controller-sa"
+                  "${EKSControlPlane.Outputs.OIDCProviderEndpoint}:sub": "system:serviceaccount:kube-system:efs-csi-controller-sa"
                 }
               }
             }


### PR DESCRIPTION
Fixes https://github.com/aws-quickstart/quickstart-amazon-eks/issues/513.

This exposes the `CreateNodeGroup` parameter in the NodeGroup template, which was added in https://github.com/aws-quickstart/quickstart-amazon-eks-nodegroup/pull/10, as an AdvancedConfiguration parameter.

There are several resources which rely on the existence of a worker node:
* AwsNodeIrsaStack
* AwsNodeTerminationHandlerHelmChart
* AmazonEksEfsCsiDriverHelmChart

AwsNodeIrsaStack is changed so that it requires `CreateNodeGroup`.  EKSControlPlane outputs are used instead of AwsNodeIrsaStack outputs where necessary (note that this reverts much of 01d8380636fe389f07d8f617be799233f141fd8b).  Note that this removes the dependency of AmazonEksEbsCsiDriverAddon on AwsNodeIrsaStack - I don't think the EBS CSI driver add-on requires IRSA to be enabled on the aws-node DaemonSet but I may be mistaken.

AwsNodeTerminationHandlerHelmChart is changed so that it requires `CreateNodeGroup`.

AmazonEksEfsCsiDriverHelmChart already depends on AwsNodeIrsaStack (although it may be clearer to make the `CreateNodeGroup` condition explicit).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.